### PR TITLE
#6998 - write errors from WCF IErrorHandler to PluginLogger

### DIFF
--- a/src/IdeaStatiCa.Plugin/ApplicationBIM.cs
+++ b/src/IdeaStatiCa.Plugin/ApplicationBIM.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 
 namespace IdeaStatiCa.Plugin
 {
+	[ErrorHandlerAttribute(typeof(WcfErrorHandler))]
 	public abstract class ApplicationBIM : IApplicationBIM
 	{
 		private IPluginLogger ideaLogger; //= IdeaDiagnostics.GetLogger("bim.plugin.application");

--- a/src/IdeaStatiCa.Plugin/AutomationHosting.cs
+++ b/src/IdeaStatiCa.Plugin/AutomationHosting.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.ServiceModel;
+using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -78,7 +80,6 @@ namespace IdeaStatiCa.Plugin
 		{
 			ideaLogger = logger ?? new NullLogger();
 
-			//ideaLogger = Diagnostics.IdeaDiagnostics.GetLogger("ideastatica.plugin.automationhosting");
 			this.Status = AutomationStatus.Unknown;
 			this.automation = hostedService;
 			this.EventName = eventName;
@@ -155,7 +156,6 @@ namespace IdeaStatiCa.Plugin
 		protected virtual void RunServer(string id, System.Threading.CancellationToken cancellationToken)
 		{
 			ideaLogger.LogInformation($"Starting sever processId = {id}");
-
 			try
 			{
 				bool isBimRunning = false;

--- a/src/IdeaStatiCa.Plugin/BIMPluginHosting.cs
+++ b/src/IdeaStatiCa.Plugin/BIMPluginHosting.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.ServiceModel;
 using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -57,6 +58,7 @@ namespace IdeaStatiCa.Plugin
 			this.EventName = eventName;
 			this.PluginUrlFormat = pluginUrlFormat;
 			ideaLogger = logger ?? new NullLogger();
+			WcfErrorHandler.InitLogger(ideaLogger);
 		}
 
 		public event ISEventHandler AppStatusChanged;

--- a/src/IdeaStatiCa.Plugin/BIMPluginHosting.cs
+++ b/src/IdeaStatiCa.Plugin/BIMPluginHosting.cs
@@ -214,7 +214,6 @@ namespace IdeaStatiCa.Plugin
 
 		private void SelfServiceHost_Faulted(object sender, EventArgs e)
 		{
-			ideaLogger.LogError($"Faulted service '{ServiceBaseAddress}', fault details = '{e?.ToString()}'.");
 		}
 
 		private void IS_Exited(object sender, EventArgs e)

--- a/src/IdeaStatiCa.Plugin/WcfErrorHandler.cs
+++ b/src/IdeaStatiCa.Plugin/WcfErrorHandler.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Dispatcher;
+
+namespace IdeaStatiCa.Plugin
+{
+	/// <summary>
+	/// For more details see https://www.c-sharpcorner.com/UploadFile/b182bf/centralize-exception-handling-in-wcf-part-10/
+	/// </summary>
+	public class ErrorHandlerAttribute : Attribute, IServiceBehavior
+	{
+		private readonly Type errorHandler;
+		public ErrorHandlerAttribute(Type errorHandler)
+		{
+			this.errorHandler = errorHandler;
+		}
+		public void AddBindingParameters(ServiceDescription serviceDescription, System.ServiceModel.ServiceHostBase serviceHostBase, System.Collections.ObjectModel.Collection<ServiceEndpoint> endpoints, System.ServiceModel.Channels.BindingParameterCollection bindingParameters)
+		{
+
+		}
+
+		public void ApplyDispatchBehavior(ServiceDescription serviceDescription, System.ServiceModel.ServiceHostBase serviceHostBase)
+		{
+			IErrorHandler handler = (IErrorHandler)Activator.CreateInstance(this.errorHandler);
+			foreach (ChannelDispatcherBase channelDispatcherBase in serviceHostBase.ChannelDispatchers)
+			{
+				ChannelDispatcher channelDispatcher = channelDispatcherBase as ChannelDispatcher;
+				if (channelDispatcher != null)
+				{
+					channelDispatcher.ErrorHandlers.Add(handler);
+				}
+			}
+		}
+
+		public void Validate(ServiceDescription serviceDescription, System.ServiceModel.ServiceHostBase serviceHostBase)
+		{
+
+		}
+	}
+
+	/// <summary>
+	/// For more details see https://www.c-sharpcorner.com/UploadFile/b182bf/centralize-exception-handling-in-wcf-part-10/
+	/// </summary>
+	public class WcfErrorHandler : IErrorHandler
+	{
+		private static object initLock = new object();
+		public static IPluginLogger  Logger { get; private set; }
+
+
+		/// <summary>
+		/// It initialize error logger for all instances of <see cref="WcfErrorHandler"/>
+		/// Only the first initialization is executed
+		/// </summary>
+		/// <param name="logger">The instance of the logger where all wcf errors will be written</param>
+		public static void InitLogger(IPluginLogger logger)
+		{
+			lock(initLock)
+			{
+				if(Logger == null)
+				{
+					Logger = logger;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Provide a fault. The Message fault parameter can be replaced, or set to null to suppress reporting a fault.
+		/// </summary>
+		/// <param name="error"></param>
+		/// <param name="version"></param>
+		/// <param name="fault"></param>
+		public void ProvideFault(Exception error, MessageVersion version, ref Message fault)
+		{
+			if (Logger != null)
+			{
+				Logger.LogWarning("WcfErrorHandler.ProvideFault", error);
+			}
+		}
+
+		/// <summary>
+		/// HandleError. Log an error, then allow the error to be handled as usual.
+		/// </summary>
+		/// <param name="error">Exception</param>
+		/// <returns>Return true if the error is considered as already handled</returns>
+		public bool HandleError(Exception error)
+		{
+			if (Logger != null)
+			{
+				Logger.LogWarning("WcfErrorHandler.HandleError", error);
+			}
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
This is a temporary solution of writing error logs from a WCF HostService which will be replaced by gRPC.
