### PR TITLE
Migrate bimapilink to net48

### DIFF
--- a/src/Examples/CCM/BimApiExample/BimApiExample.csproj
+++ b/src/Examples/CCM/BimApiExample/BimApiExample.csproj
@@ -2,8 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows</TargetFramework>
-		<Nullable>enable</Nullable>
+		<TargetFrameworks>net6.0-windows;net48</TargetFrameworks>
 		<UseWPF>true</UseWPF>
 		<ProjectGuid>{669835E3-E2A5-48E5-8CF4-752370CB7051}</ProjectGuid>
 	</PropertyGroup>
@@ -15,7 +14,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\BimApiLinkFeaExample\BimApiLinkFeaExample.csproj" />
+		<ProjectReference Include="..\BimApiLinkFeaExample\BimApiLinkFeaExample.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Examples/CCM/BimApiExample/Properties/Settings.Designer.cs
+++ b/src/Examples/CCM/BimApiExample/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace BimApiExample.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/Examples/CCM/BimApiExample/ViewModels/AppLogger.cs
+++ b/src/Examples/CCM/BimApiExample/ViewModels/AppLogger.cs
@@ -24,9 +24,9 @@ namespace BimApiExample.ViewModels
 
 		public bool EnableDebug { get; set; }
 
-		public ObservableCollection<MessageViewModel> Messages { get; } = new();
+		public ObservableCollection<MessageViewModel> Messages { get; } = new ObservableCollection<MessageViewModel>();
 
-		public void LogDebug(string message, Exception? ex = null)
+		public void LogDebug(string message, Exception ex = null)
 		{
 			if (EnableDebug)
 			{
@@ -34,17 +34,17 @@ namespace BimApiExample.ViewModels
 			}
 		}
 
-		public void LogError(string message, Exception? ex = null)
+		public void LogError(string message, Exception ex = null)
 		{
 			Log(MessageSeverity.Error, message, ex);
 		}
 
-		public void LogInformation(string message, Exception? ex = null)
+		public void LogInformation(string message, Exception ex = null)
 		{
 			Log(MessageSeverity.Information, message, ex);
 		}
 
-		public void LogTrace(string message, Exception? ex = null)
+		public void LogTrace(string message, Exception ex = null)
 		{
 			if (EnableTrace)
 			{
@@ -52,16 +52,16 @@ namespace BimApiExample.ViewModels
 			}
 		}
 
-		public void LogWarning(string message, Exception? ex = null)
+		public void LogWarning(string message, Exception ex = null)
 		{
 			Log(MessageSeverity.Warning, message, ex);
 		}
 
-		private void Log(MessageSeverity severity, string message, Exception? ex)
+		private void Log(MessageSeverity severity, string message, Exception ex)
 		{
 			uiDispatcher.BeginInvoke(new Action(() =>
 			{
-				Messages.Add(new(severity, message, ex));
+				Messages.Add(new MessageViewModel(severity, message, ex));
 			}));
 		}
 

--- a/src/Examples/CCM/BimApiExample/ViewModels/MessageViewModel.cs
+++ b/src/Examples/CCM/BimApiExample/ViewModels/MessageViewModel.cs
@@ -2,24 +2,24 @@
 
 namespace BimApiExample.ViewModels
 {
-	internal record MessageViewModel
+	internal class MessageViewModel
 	{
-		public MessageViewModel(MessageSeverity severity, string message, Exception? exception = null)
+		public MessageViewModel(MessageSeverity severity, string message, Exception exception = null)
 		{
 			Message = message;
 			Exception = exception;
 			Severity = severity;
 		}
 
-		public string Message { get; init; }
+		public string Message { get; set; }
 
-		public Exception? Exception { get; init; }
+		public Exception Exception { get; set; }
 
-		public MessageSeverity Severity { get; init; }
+		public MessageSeverity Severity { get; set; }
 
 		public override string ToString()
 		{
-			if (Exception is not null)
+			if (Exception != null)
 			{
 				return $"{Message}\r\n{Exception}";
 			}

--- a/src/Examples/CCM/BimApiExample/Views/MainWindow.xaml.cs
+++ b/src/Examples/CCM/BimApiExample/Views/MainWindow.xaml.cs
@@ -1,9 +1,4 @@
 ﻿using BimApiExample.ViewModels;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -18,9 +13,9 @@ namespace BimApiExample.Views
 		public MainWindow()
 		{
 			InitializeComponent();
-			MainWindowViewModel viewModel = new();
+			MainWindowViewModel viewModel = new MainWindowViewModel();
 			DataContext = viewModel;
-			viewModel.Logger.Messages.CollectionChanged += (_, _) =>
+			viewModel.Logger.Messages.CollectionChanged += (_, __) =>
 			{
 				if (VisualTreeHelper.GetChildrenCount(listView) > 0)
 				{

--- a/src/Examples/CCM/BimApiExample/Views/MessageTemplateSelector.cs
+++ b/src/Examples/CCM/BimApiExample/Views/MessageTemplateSelector.cs
@@ -6,13 +6,13 @@ namespace BimApiExample.Views
 {
 	internal class MessageTemplateSelector : DataTemplateSelector
 	{
-		public DataTemplate? StandardTemplate { get; set; }
+		public DataTemplate StandardTemplate { get; set; }
 
-		public DataTemplate? ExceptionTemplate { get; set; }
+		public DataTemplate ExceptionTemplate { get; set; }
 
 		public override DataTemplate SelectTemplate(object item, DependencyObject container)
 		{
-			if (item is MessageViewModel vm && StandardTemplate is not null && ExceptionTemplate is not null)
+			if (item is MessageViewModel vm && StandardTemplate != null && ExceptionTemplate != null)
 			{
 				return vm.Exception == null
 					? StandardTemplate

--- a/src/Examples/CCM/BimApiLinkFeaExample/BimApi/CrossSectionByName.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/BimApi/CrossSectionByName.cs
@@ -7,7 +7,7 @@ namespace BimApiLinkFeaExample.BimApi
 	{
 		public override IIdeaMaterial Material => Get<IIdeaMaterial>(MaterialNo);
 
-		public int MaterialNo { get; init; }
+		public int MaterialNo { get; set; }
 
 		public CrossSectionByName(int no) : base(no)
 		{

--- a/src/Examples/CCM/BimApiLinkFeaExample/BimApi/Member1D.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/BimApi/Member1D.cs
@@ -5,7 +5,7 @@ namespace BimApiLinkFeaExample.BimApi
 {
 	internal class Member1D : IdeaMember1D
 	{
-		public int CrossSectionNo { get; init; }
+		public int CrossSectionNo { get; set; }
 
 		public override IIdeaCrossSection CrossSection => Get<IIdeaCrossSection>(CrossSectionNo);
 

--- a/src/Examples/CCM/BimApiLinkFeaExample/BimApi/Segment3D.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/BimApi/Segment3D.cs
@@ -9,9 +9,9 @@ namespace BimApiLinkFeaExample.BimApi
 
 		public override IIdeaNode EndNode => Get<IIdeaNode>(EndNodeNo);
 
-		public int StartNodeNo { get; init; }
+		public int StartNodeNo { get; set; }
 
-		public int EndNodeNo { get; init; }
+		public int EndNodeNo { get; set; }
 
 		public Segment3D(int no)
 			: base(no)

--- a/src/Examples/CCM/BimApiLinkFeaExample/BimApiLinkFeaExample.csproj
+++ b/src/Examples/CCM/BimApiLinkFeaExample/BimApiLinkFeaExample.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-windows</TargetFramework>
-		<Nullable>enable</Nullable>
-		<UseWPF>true</UseWPF>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<!--<Nullable>enable</Nullable>-->
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Examples/CCM/BimApiLinkFeaExample/FeaExampleApi/FeaApi.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/FeaExampleApi/FeaApi.cs
@@ -1,0 +1,12 @@
+﻿namespace BimApiLinkFeaExample.FeaExampleApi
+{
+	internal interface IFeaApi
+	{
+		IFeaGeometryApi Geometry { get; }
+	}
+
+	internal class FeaApi : IFeaApi
+	{
+		public IFeaGeometryApi Geometry { get; } = new FeaGeometryApi();
+	}
+}

--- a/src/Examples/CCM/BimApiLinkFeaExample/FeaExampleApi/FeaGeometryApi.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/FeaExampleApi/FeaGeometryApi.cs
@@ -1,0 +1,82 @@
+﻿using MathNet.Spatial.Euclidean;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace BimApiLinkFeaExample.FeaExampleApi
+{
+	public interface IFeaGeometryApi
+	{
+		IFeaMember GetMember(int id);
+
+		(UnitVector3D X, UnitVector3D Y, UnitVector3D Z) GetMemberLcs(int id);
+
+		IEnumerable<int> GetMembersIdentifiers();
+
+		IFeaNode GetNode(int id);
+
+		IEnumerable<int> GetNodesIdentifiers();
+	}
+
+	internal class FeaGeometryApi : IFeaGeometryApi
+	{
+		private List<IFeaMember> _members = InitializeMembers();
+		private List<IFeaNode> _nodes = InitializeNodes();
+
+		public IFeaMember GetMember(int id) => _members.FirstOrDefault(m => m.Id == id);
+
+		public (UnitVector3D X, UnitVector3D Y, UnitVector3D Z) GetMemberLcs(int id)
+		{
+			var member = GetMember(id);
+			IFeaNode beg = GetNode(member.BeginNode);
+			IFeaNode end = GetNode(member.EndNode);
+			return CalculateMemberLcs(beg, end);
+		}
+
+		public IEnumerable<int> GetMembersIdentifiers() => _members.Select(m => m.Id);
+
+		public IFeaNode GetNode(int id) => _nodes.FirstOrDefault(n => n.Id == id);
+
+		public IEnumerable<int> GetNodesIdentifiers() => _nodes.Select(n => n.Id);
+
+		private static (UnitVector3D X, UnitVector3D Y, UnitVector3D Z) CalculateMemberLcs(IFeaNode begin, IFeaNode end)
+		{
+			Vector3D memberX = end.Point - begin.Point;
+			UnitVector3D globalZ = UnitVector3D.ZAxis;
+
+			UnitVector3D memberY;
+
+			if (memberX.IsParallelTo(globalZ))
+			{
+				// column
+				memberY = UnitVector3D.YAxis;
+			}
+			else
+			{
+				// beam
+				memberY = memberX.CrossProduct(globalZ).Normalize().Negate();
+			}
+
+			return (memberX.Normalize(), memberY, memberX.CrossProduct(memberY).Normalize());
+		}
+
+		private static List<IFeaMember> InitializeMembers()
+		{
+			return new List<IFeaMember>()
+			{
+				new FeaMember { Id = 1, BeginNode = 1, EndNode = 2, CrossSectionId = 1, },
+				new FeaMember { Id = 2, BeginNode = 2, EndNode = 3, CrossSectionId = 1, },
+			};
+		}
+
+		private static List<IFeaNode> InitializeNodes()
+		{
+			return new List<IFeaNode>()
+			{
+				new FeaNode(1, 0, 0, 0),
+				new FeaNode(2, 0, 0, 3),
+				new FeaNode(3, 5, 0, 3),
+			};
+		}
+	}
+}

--- a/src/Examples/CCM/BimApiLinkFeaExample/FeaExampleApi/FeaMember.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/FeaExampleApi/FeaMember.cs
@@ -1,0 +1,18 @@
+﻿namespace BimApiLinkFeaExample.FeaExampleApi
+{
+	public interface IFeaMember
+	{
+		int Id { get; }
+		int BeginNode { get; }
+		int EndNode { get; }
+		int CrossSectionId { get; }
+	}
+
+	public class FeaMember : IFeaMember
+	{
+		public int Id { get; set; }
+		public int BeginNode { get; set; }
+		public int EndNode { get; set; }
+		public int CrossSectionId { get; set; }
+	}
+}

--- a/src/Examples/CCM/BimApiLinkFeaExample/FeaExampleApi/FeaNode.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/FeaExampleApi/FeaNode.cs
@@ -1,0 +1,34 @@
+﻿using MathNet.Spatial.Euclidean;
+
+namespace BimApiLinkFeaExample.FeaExampleApi
+{
+	public interface IFeaNode
+	{
+		int Id { get; }
+		double X { get; }
+		double Y { get; }
+		double Z { get; }
+
+		Point3D Point { get; }
+	}
+
+	internal class FeaNode : IFeaNode
+	{
+		public FeaNode(int id, double x, double y, double z)
+		{
+			Id = id;
+			X = x;
+			Y = y;
+			Z = z;
+		}
+
+		public int Id { get; set; }
+
+		public double X { get; set; }
+
+		public double Y { get; set; }
+		public double Z { get; set; }
+
+		public Point3D Point => new Point3D(X, Y, Z);
+	}
+}

--- a/src/Examples/CCM/BimApiLinkFeaExample/Importers/NodeImporter.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/Importers/NodeImporter.cs
@@ -1,4 +1,5 @@
-﻿using IdeaStatica.BimApiLink.BimApi;
+﻿using BimApiLinkFeaExample.FeaExampleApi;
+using IdeaStatica.BimApiLink.BimApi;
 using IdeaStatica.BimApiLink.Importers;
 using IdeaStatiCa.BimApi;
 using System;
@@ -7,8 +8,11 @@ namespace BimApiLinkFeaExample.Importers
 {
 	internal class NodeImporter : IntIdentifierImporter<IIdeaNode>
 	{
-		public NodeImporter(/*TODO pass API using DI*/)
+		private readonly IFeaGeometryApi geometry;
+
+		public NodeImporter(IFeaGeometryApi geometry)
 		{
+			this.geometry = geometry;
 		}
 
 		public override IIdeaNode Create(int id)
@@ -20,15 +24,10 @@ namespace BimApiLinkFeaExample.Importers
 			};
 		}
 
-		private static IdeaVector3D GetLocation(int id)
+		private IdeaVector3D GetLocation(int id)
 		{
-			return id switch
-			{
-				1 => new IdeaVector3D(0, 0, 0),
-				2 => new IdeaVector3D(0, 0, 3),
-				3 => new IdeaVector3D(5, 0, 3),
-				_ => throw new NotImplementedException(),
-			};
+			IFeaNode feaNode = geometry.GetNode(id);
+			return new IdeaVector3D(feaNode.X, feaNode.Y, feaNode.Z);
 		}
 	}
 }

--- a/src/Examples/CCM/BimApiLinkFeaExample/Model.cs
+++ b/src/Examples/CCM/BimApiLinkFeaExample/Model.cs
@@ -1,4 +1,5 @@
-﻿using IdeaRS.OpenModel;
+﻿using BimApiLinkFeaExample.FeaExampleApi;
+using IdeaRS.OpenModel;
 using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatica.BimApiLink.Plugin;
 using IdeaStatiCa.BimApi;
@@ -10,10 +11,12 @@ namespace BimApiLinkFeaExample
 {
 	internal class Model : IFeaModel
 	{
+		private readonly IFeaGeometryApi geometry;
 		private readonly IProgressMessaging messagingService;
 
-		public Model(IProgressMessaging messagingService)
+		public Model(IFeaGeometryApi geometry, IProgressMessaging messagingService)
 		{
+			this.geometry = geometry;
 			this.messagingService = messagingService;
 		}
 
@@ -31,7 +34,7 @@ namespace BimApiLinkFeaExample
 		/// <returns>All members in the model to be able find all related (connected) members, when select node only.</returns>
 		public IEnumerable<Identifier<IIdeaMember1D>> GetAllMembers()
 		{
-			return new int[] { 1, 2, }
+			return geometry.GetMembersIdentifiers()
 				.Select(x => new IntIdentifier<IIdeaMember1D>(x));
 		}
 
@@ -44,12 +47,12 @@ namespace BimApiLinkFeaExample
 		/// <returns></returns>
 		public FeaUserSelection GetUserSelection()
 		{
-			List<Identifier<IIdeaNode>> nodes = new int[] { 1, 2, 3, }
+			List<Identifier<IIdeaNode>> nodes = geometry.GetNodesIdentifiers()
 				.Select(x => new IntIdentifier<IIdeaNode>(x))
 				.Cast<Identifier<IIdeaNode>>()
 				.ToList();
 
-			List<Identifier<IIdeaMember1D>> members = new int[] { 1, 2, }
+			List<Identifier<IIdeaMember1D>> members = geometry.GetMembersIdentifiers()
 				.Select(x => new IntIdentifier<IIdeaMember1D>(x))
 				.Cast<Identifier<IIdeaMember1D>>()
 				.ToList();

--- a/src/IdeaStatica.BimApiLink/BimApi/AbstractIdeaObject.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/AbstractIdeaObject.cs
@@ -1,5 +1,6 @@
 ﻿using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
+using System;
 
 namespace IdeaStatica.BimApiLink.BimApi
 {
@@ -20,9 +21,9 @@ namespace IdeaStatica.BimApiLink.BimApi
 		public override int GetHashCode()
 			=> Id.GetHashCode();
 
-		public override bool Equals(object? obj)
+		public override bool Equals(object obj)
 		{
-			if (obj is not AbstractIdeaObject<T> other)
+			if (!(obj is AbstractIdeaObject<T> other))
 			{
 				return false;
 			}
@@ -30,7 +31,7 @@ namespace IdeaStatica.BimApiLink.BimApi
 			return Equals(other);
 		}
 
-		public bool Equals(AbstractIdeaObject<T>? other)
+		public bool Equals(AbstractIdeaObject<T> other)
 		{
 			if (other is null)
 			{

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaCombiInput.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaCombiInput.cs
@@ -1,5 +1,6 @@
 using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.BimApi
 {
@@ -9,7 +10,7 @@ namespace IdeaStatica.BimApiLink.BimApi
 		
 		public virtual IdeaRS.OpenModel.Loading.TypeCalculationCombiEC TypeCalculationCombi { get; set; }
 		
-		public virtual List<IIdeaCombiItem> CombiItems { get; set; } = null!;
+		public virtual List<IIdeaCombiItem> CombiItems { get; set; } = null;
 		
 		protected IdeaCombiInput(Identifier<IIdeaCombiInput> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaCombiItem.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaCombiItem.cs
@@ -5,11 +5,11 @@ namespace IdeaStatica.BimApiLink.BimApi
 {
 	public class IdeaCombiItem : AbstractIdeaObject<IIdeaCombiItem>, IIdeaCombiItem
 	{
-		public virtual IIdeaLoadCase LoadCase { get; set; } = null!;
+		public virtual IIdeaLoadCase LoadCase { get; set; } = null;
 		
 		public virtual double Coeff { get; set; }
 		
-		public virtual IIdeaCombiInput Combination { get; set; } = null!;
+		public virtual IIdeaCombiInput Combination { get; set; } = null;
 		
 		protected IdeaCombiItem(Identifier<IIdeaCombiItem> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaCrossSectionByComponents.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaCrossSectionByComponents.cs
@@ -1,5 +1,6 @@
 using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.BimApi
 {
@@ -7,7 +8,7 @@ namespace IdeaStatica.BimApiLink.BimApi
 	{
 		public virtual double Rotation { get; set; }
 		
-		public virtual HashSet<IIdeaCrossSectionComponent> Components { get; set; } = null!;
+		public virtual HashSet<IIdeaCrossSectionComponent> Components { get; set; } = null;
 		
 		protected IdeaCrossSectionByComponents(Identifier<IIdeaCrossSectionByComponents> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaCrossSectionByName.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaCrossSectionByName.cs
@@ -7,7 +7,7 @@ namespace IdeaStatica.BimApiLink.BimApi
 	{
 		public virtual double Rotation { get; set; }
 		
-		public virtual IIdeaMaterial Material { get; set; } = null!;
+		public virtual IIdeaMaterial Material { get; set; } = null;
 		
 		protected IdeaCrossSectionByName(Identifier<IIdeaCrossSectionByName> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaCrossSectionByParameters.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaCrossSectionByParameters.cs
@@ -1,5 +1,6 @@
 using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.BimApi
 {
@@ -7,11 +8,11 @@ namespace IdeaStatica.BimApiLink.BimApi
 	{
 		public virtual double Rotation { get; set; }
 		
-		public virtual IIdeaMaterial Material { get; set; } = null!;
+		public virtual IIdeaMaterial Material { get; set; } = null;
 		
 		public virtual IdeaRS.OpenModel.CrossSection.CrossSectionType Type { get; set; }
 		
-		public virtual HashSet<IdeaRS.OpenModel.CrossSection.Parameter> Parameters { get; set; } = null!;
+		public virtual HashSet<IdeaRS.OpenModel.CrossSection.Parameter> Parameters { get; set; } = null;
 		
 		protected IdeaCrossSectionByParameters(Identifier<IIdeaCrossSectionByParameters> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaElement1D.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaElement1D.cs
@@ -1,14 +1,16 @@
 using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimApi.Results;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IdeaStatica.BimApiLink.BimApi
 {
 	public class IdeaElement1D : AbstractIdeaObject<IIdeaElement1D>, IIdeaElement1D
 	{
-		public virtual IIdeaCrossSection StartCrossSection { get; set; } = null!;
+		public virtual IIdeaCrossSection StartCrossSection { get; set; } = null;
 
-		public virtual IIdeaCrossSection EndCrossSection { get; set; } = null!;
+		public virtual IIdeaCrossSection EndCrossSection { get; set; } = null;
 
 		public virtual IdeaVector3D EccentricityBegin { get; set; } = new IdeaVector3D(0, 0, 0);
 
@@ -16,7 +18,7 @@ namespace IdeaStatica.BimApiLink.BimApi
 
 		public virtual double RotationRx { get; set; }
 
-		public virtual IIdeaSegment3D Segment { get; set; } = null!;
+		public virtual IIdeaSegment3D Segment { get; set; } = null;
 
 		protected IdeaElement1D(Identifier<IIdeaElement1D> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaLineSegment3D.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaLineSegment3D.cs
@@ -5,11 +5,11 @@ namespace IdeaStatica.BimApiLink.BimApi
 {
 	public class IdeaLineSegment3D : AbstractIdeaObject<IIdeaLineSegment3D>, IIdeaLineSegment3D
 	{
-		public virtual IIdeaNode StartNode { get; set; } = null!;
+		public virtual IIdeaNode StartNode { get; set; } = null;
 		
-		public virtual IIdeaNode EndNode { get; set; } = null!;
+		public virtual IIdeaNode EndNode { get; set; } = null;
 		
-		public virtual IdeaRS.OpenModel.Geometry3D.CoordSystem LocalCoordinateSystem { get; set; } = null!;
+		public virtual IdeaRS.OpenModel.Geometry3D.CoordSystem LocalCoordinateSystem { get; set; } = null;
 		
 		protected IdeaLineSegment3D(Identifier<IIdeaLineSegment3D> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaLoadCase.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaLoadCase.cs
@@ -11,9 +11,9 @@ namespace IdeaStatica.BimApiLink.BimApi
 		
 		public virtual IdeaRS.OpenModel.Loading.VariableType Variable { get; set; }
 		
-		public virtual IIdeaLoadGroup LoadGroup { get; set; } = null!;
+		public virtual IIdeaLoadGroup LoadGroup { get; set; } = null;
 		
-		public virtual string Description { get; set; } = null!;
+		public virtual string Description { get; set; } = null;
 		
 		protected IdeaLoadCase(Identifier<IIdeaLoadCase> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaMaterialConcrete.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaMaterialConcrete.cs
@@ -5,7 +5,7 @@ namespace IdeaStatica.BimApiLink.BimApi
 {
 	public class IdeaMaterialConcrete : AbstractIdeaObject<IIdeaMaterialConcrete>, IIdeaMaterialConcrete
 	{
-		public virtual IdeaRS.OpenModel.Material.MatConcrete Material { get; set; } = null!;
+		public virtual IdeaRS.OpenModel.Material.MatConcrete Material { get; set; } = null;
 		
 		protected IdeaMaterialConcrete(Identifier<IIdeaMaterialConcrete> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaMaterialSteel.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaMaterialSteel.cs
@@ -5,7 +5,7 @@ namespace IdeaStatica.BimApiLink.BimApi
 {
 	public class IdeaMaterialSteel : AbstractIdeaObject<IIdeaMaterialSteel>, IIdeaMaterialSteel
 	{
-		public virtual IdeaRS.OpenModel.Material.MatSteel Material { get; set; } = null!;
+		public virtual IdeaRS.OpenModel.Material.MatSteel Material { get; set; } = null;
 		
 		protected IdeaMaterialSteel(Identifier<IIdeaMaterialSteel> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaMember1D.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaMember1D.cs
@@ -1,6 +1,8 @@
 using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimApi.Results;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IdeaStatica.BimApiLink.BimApi
 {
@@ -10,11 +12,11 @@ namespace IdeaStatica.BimApiLink.BimApi
 
 		public virtual IdeaRS.OpenModel.Model.Member1DType Type { get; set; }
 
-		public virtual List<IIdeaElement1D> Elements { get; set; } = null!;
+		public virtual List<IIdeaElement1D> Elements { get; set; } = null;
 
-		public virtual IIdeaTaper Taper { get; set; } = null!;
+		public virtual IIdeaTaper Taper { get; set; } = null;
 
-		public virtual IIdeaCrossSection CrossSection { get; set; } = null!;
+		public virtual IIdeaCrossSection CrossSection { get; set; } = null;
 
 		public virtual IdeaRS.OpenModel.Model.Alignment Alignment { get; set; }
 

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaModel.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaModel.cs
@@ -1,5 +1,7 @@
 ﻿using IdeaRS.OpenModel;
 using IdeaStatiCa.BimApi;
+using System;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.BimApi
 {

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaNode.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaNode.cs
@@ -7,7 +7,7 @@ namespace IdeaStatica.BimApiLink.BimApi
 	{
 		public virtual IIdeaPersistenceToken Token { get; set; }
 		
-		public virtual IdeaVector3D Vector { get; set; } = null!;
+		public virtual IdeaVector3D Vector { get; set; } = null;
 		
 		protected IdeaNode(Identifier<IIdeaNode> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaSpan.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaSpan.cs
@@ -5,9 +5,9 @@ namespace IdeaStatica.BimApiLink.BimApi
 {
 	public class IdeaSpan : AbstractIdeaObject<IIdeaSpan>, IIdeaSpan
 	{
-		public virtual IIdeaCrossSection StartCrossSection { get; set; } = null!;
+		public virtual IIdeaCrossSection StartCrossSection { get; set; } = null;
 		
-		public virtual IIdeaCrossSection EndCrossSection { get; set; } = null!;
+		public virtual IIdeaCrossSection EndCrossSection { get; set; } = null;
 		
 		public virtual double StartPosition { get; set; }
 		

--- a/src/IdeaStatica.BimApiLink/BimApi/IdeaTaper.cs
+++ b/src/IdeaStatica.BimApiLink/BimApi/IdeaTaper.cs
@@ -1,11 +1,12 @@
 using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.BimApi
 {
 	public class IdeaTaper : AbstractIdeaObject<IIdeaTaper>, IIdeaTaper
 	{
-		public virtual IEnumerable<IIdeaSpan> Spans { get; set; } = null!;
+		public virtual IEnumerable<IIdeaSpan> Spans { get; set; } = null;
 		
 		protected IdeaTaper(Identifier<IIdeaTaper> identifer)
 			: base(identifer)

--- a/src/IdeaStatica.BimApiLink/BimLinkObject.cs
+++ b/src/IdeaStatica.BimApiLink/BimLinkObject.cs
@@ -3,6 +3,7 @@ using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatica.BimApiLink.Importers;
 using IdeaStatica.BimApiLink.Scoping;
 using IdeaStatiCa.BimApi;
+using System;
 
 namespace IdeaStatica.BimApiLink
 {
@@ -11,37 +12,55 @@ namespace IdeaStatica.BimApiLink
 		protected T Get<T>(Identifier<T> identifier)
 			where T : IIdeaObject
 		{
-			return GetMaybe(identifier) ?? throw new InvalidOperationException();
+			T o = GetMaybe(identifier);
+			if (o == null)
+			{
+				throw new InvalidOperationException();
+			}
+
+			return o;
 		}
 
 		protected T Get<T>(int id)
 			where T : IIdeaObject
 		{
-			return GetMaybe<T>(id) ?? throw new InvalidOperationException();
+			T o = GetMaybe<T>(id);
+			if (o == null)
+			{
+				throw new InvalidOperationException();
+			}
+
+			return o;
 		}
 
 		protected T Get<T>(string id)
 			where T : IIdeaObject
 		{
-			return GetMaybe<T>(id) ?? throw new InvalidOperationException();
+			T o = GetMaybe<T>(id);
+			if (o == null)
+			{
+				throw new InvalidOperationException();
+			}
+
+			return o;
 		}
 
-		protected T? GetMaybe<T>(Identifier<T> identifier)
+		protected T GetMaybe<T>(Identifier<T> identifier)
 			where T : IIdeaObject
 			=> BimApiImporter.Get(identifier);
 
-		protected T? GetMaybe<T>(int id)
+		protected T GetMaybe<T>(int id)
 			where T : IIdeaObject
 			=> Get(new IntIdentifier<T>(id));
 
-		protected T? GetMaybe<T>(string id)
+		protected T GetMaybe<T>(string id)
 			where T : IIdeaObject
 			=> Get(new StringIdentifier<T>(id));
 
 		protected CountryCode CountryCode
 			=> Scope.CountryCode;
 
-		protected object? UserData
+		protected object UserData
 			=> Scope.UserData;
 
 		internal IBimApiImporter BimApiImporter

--- a/src/IdeaStatica.BimApiLink/Hooks/AbstractHookManager.cs
+++ b/src/IdeaStatica.BimApiLink/Hooks/AbstractHookManager.cs
@@ -1,8 +1,11 @@
-﻿namespace IdeaStatica.BimApiLink.Hooks
+﻿using System;
+using System.Collections.Generic;
+
+namespace IdeaStatica.BimApiLink.Hooks
 {
 	internal class AbstractHookManager<T>
 	{
-		private readonly List<T> _hooks = new();
+		private readonly List<T> _hooks = new List<T>();
 
 		public void Add(T obj)
 		{

--- a/src/IdeaStatica.BimApiLink/Hooks/HookManagers.cs
+++ b/src/IdeaStatica.BimApiLink/Hooks/HookManagers.cs
@@ -2,8 +2,8 @@
 {
 	internal class HookManagers
 	{
-		public ImporterHookManager ImporterHookManager { get; } = new();
+		public ImporterHookManager ImporterHookManager { get; } = new ImporterHookManager();
 
-		public PluginHookManager PluginHookManager { get; } = new();
+		public PluginHookManager PluginHookManager { get; } = new PluginHookManager();
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Hooks/IImporterHook.cs
+++ b/src/IdeaStatica.BimApiLink/Hooks/IImporterHook.cs
@@ -7,6 +7,6 @@ namespace IdeaStatica.BimApiLink.Hooks
 	{
 		void EnterCreate(IIdentifier identifier);
 
-		void ExitCreate(IIdentifier identifier, IIdeaObject? ideaObject);
+		void ExitCreate(IIdentifier identifier, IIdeaObject ideaObject);
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Hooks/ImporterHookManager.cs
+++ b/src/IdeaStatica.BimApiLink/Hooks/ImporterHookManager.cs
@@ -5,7 +5,7 @@ namespace IdeaStatica.BimApiLink.Hooks
 {
 	internal class ImporterHookManager : AbstractHookManager<IImporterHook>, IImporterHook
 	{
-		public void ExitCreate(IIdentifier identifier, IIdeaObject? ideaObject)
+		public void ExitCreate(IIdentifier identifier, IIdeaObject ideaObject)
 			=> Invoke(x => x.ExitCreate(identifier, ideaObject));
 
 		public void EnterCreate(IIdentifier identifier)

--- a/src/IdeaStatica.BimApiLink/IBimUserDataSource.cs
+++ b/src/IdeaStatica.BimApiLink/IBimUserDataSource.cs
@@ -2,6 +2,6 @@
 {
 	public interface IBimUserDataSource
 	{
-		object? GetUserData();
+		object GetUserData();
 	}
 }

--- a/src/IdeaStatica.BimApiLink/IdeaStatica.BimApiLink.csproj
+++ b/src/IdeaStatica.BimApiLink/IdeaStatica.BimApiLink.csproj
@@ -20,6 +20,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\IdeaStatiCa.BimApi\IdeaStatiCa.BimApi.csproj" />
 		<ProjectReference Include="..\IdeaStatiCa.BimImporter\IdeaStatiCa.BimImporter.csproj" />
 		<ProjectReference Include="..\IdeaStatiCa.Plugin\IdeaStatiCa.Plugin.csproj" />

--- a/src/IdeaStatica.BimApiLink/IdeaStatica.BimApiLink.csproj
+++ b/src/IdeaStatica.BimApiLink/IdeaStatica.BimApiLink.csproj
@@ -1,26 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Configurations>Debug;Release</Configurations>
-    <Authors>IDEA StatiCa</Authors>
-    <Company>IDEA StatiCa</Company>
-    <PackageProjectUrl>https://github.com/idea-statica/ideastatica-public</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/idea-statica/ideastatica-public.git</RepositoryUrl>
-    <RepositoryType>Git</RepositoryType>
-    <PackageTags>IdeaStatiCa;BIM;C#;FEA;IOM;IdeaOpenModel</PackageTags>
-    <EnforceCodeStyleInBuild>False</EnforceCodeStyleInBuild>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net48;net6.0</TargetFrameworks>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<Configurations>Debug;Release</Configurations>
+		<Authors>IDEA StatiCa</Authors>
+		<Company>IDEA StatiCa</Company>
+		<PackageProjectUrl>https://github.com/idea-statica/ideastatica-public</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/idea-statica/ideastatica-public.git</RepositoryUrl>
+		<RepositoryType>Git</RepositoryType>
+		<PackageTags>IdeaStatiCa;BIM;C#;FEA;IOM;IdeaOpenModel</PackageTags>
+		<EnforceCodeStyleInBuild>False</EnforceCodeStyleInBuild>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\IdeaStatiCa.BimApi\IdeaStatiCa.BimApi.csproj" />
-    <ProjectReference Include="..\IdeaStatiCa.BimImporter\IdeaStatiCa.BimImporter.csproj" />
-    <ProjectReference Include="..\IdeaStatiCa.Plugin\IdeaStatiCa.Plugin.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\IdeaStatiCa.BimApi\IdeaStatiCa.BimApi.csproj" />
+		<ProjectReference Include="..\IdeaStatiCa.BimImporter\IdeaStatiCa.BimImporter.csproj" />
+		<ProjectReference Include="..\IdeaStatiCa.Plugin\IdeaStatiCa.Plugin.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/IdeaStatica.BimApiLink/Identifiers/IIdentifer.cs
+++ b/src/IdeaStatica.BimApiLink/Identifiers/IIdentifer.cs
@@ -1,20 +1,21 @@
 ﻿using IdeaStatiCa.BimApi;
+using System;
 
 namespace IdeaStatica.BimApiLink.Identifiers
 {
 	public interface IIdentifier : IIdeaPersistenceToken, IEquatable<IIdentifier>
 	{
-		public Type ObjectType { get; }
+		Type ObjectType { get; }
 	}
 
-	public abstract record Identifier<T> : IIdentifier
+	public abstract class Identifier<T> : IIdentifier
 		where T : IIdeaObject
 	{
 		public Type ObjectType => typeof(T);
 
 		public abstract string GetStringId();
 
-		public bool Equals(IIdentifier? other)
+		public bool Equals(IIdentifier other)
 			=> other is Identifier<T> id && Equals(id);
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Identifiers/IIdentifer.cs
+++ b/src/IdeaStatica.BimApiLink/Identifiers/IIdentifer.cs
@@ -7,15 +7,4 @@ namespace IdeaStatica.BimApiLink.Identifiers
 	{
 		Type ObjectType { get; }
 	}
-
-	public abstract class Identifier<T> : IIdentifier
-		where T : IIdeaObject
-	{
-		public Type ObjectType => typeof(T);
-
-		public abstract string GetStringId();
-
-		public bool Equals(IIdentifier other)
-			=> other is Identifier<T> id && Equals(id);
-	}
 }

--- a/src/IdeaStatica.BimApiLink/Identifiers/Identifier.cs
+++ b/src/IdeaStatica.BimApiLink/Identifiers/Identifier.cs
@@ -1,0 +1,44 @@
+﻿using IdeaStatiCa.BimApi;
+using System;
+
+namespace IdeaStatica.BimApiLink.Identifiers
+{
+	public abstract class Identifier<T> : IIdentifier
+		where T : IIdeaObject
+	{
+		public Type ObjectType => typeof(T);
+
+		public abstract string GetStringId();
+
+		public virtual bool Equals(IIdentifier other)
+		{
+			if (!(other is Identifier<T> otherId))
+			{
+				return false;
+			}
+
+			return ObjectType == otherId.ObjectType &&
+				GetStringId() == otherId.GetStringId();
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (!(obj is Identifier<T> other))
+			{
+				return false;
+			}
+
+			if (ReferenceEquals(this, other))
+			{
+				return true;
+			}
+
+			return Equals(other);
+		}
+
+		public override int GetHashCode()
+		{
+			return HashCode.Combine(ObjectType, GetStringId());
+		}
+	}
+}

--- a/src/IdeaStatica.BimApiLink/Identifiers/ImmutableIdentifier.cs
+++ b/src/IdeaStatica.BimApiLink/Identifiers/ImmutableIdentifier.cs
@@ -1,0 +1,17 @@
+﻿using IdeaStatiCa.BimApi;
+
+namespace IdeaStatica.BimApiLink.Identifiers
+{
+	public abstract class ImmutableIdentifier<T> : Identifier<T>
+		where T : IIdeaObject
+	{
+		private readonly string _stringId;
+
+		protected ImmutableIdentifier(string stringId)
+		{
+			_stringId = stringId;
+		}
+
+		public override string GetStringId() => _stringId;
+	}
+}

--- a/src/IdeaStatica.BimApiLink/Identifiers/IntIdentifier.cs
+++ b/src/IdeaStatica.BimApiLink/Identifiers/IntIdentifier.cs
@@ -2,16 +2,15 @@
 
 namespace IdeaStatica.BimApiLink.Identifiers
 {
-	public class IntIdentifier<T> : Identifier<T>
+	public class IntIdentifier<T> : ImmutableIdentifier<T>
 		where T : IIdeaObject
 	{
 		public int Id { get; }
 
 		public IntIdentifier(int id)
+			: base(typeof(T).FullName + "-" + id.ToString())
 		{
 			Id = id;
 		}
-
-		public override string GetStringId() => typeof(T).FullName + "-" + Id.ToString();
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Identifiers/IntIdentifier.cs
+++ b/src/IdeaStatica.BimApiLink/Identifiers/IntIdentifier.cs
@@ -2,7 +2,7 @@
 
 namespace IdeaStatica.BimApiLink.Identifiers
 {
-	public record IntIdentifier<T> : Identifier<T>
+	public class IntIdentifier<T> : Identifier<T>
 		where T : IIdeaObject
 	{
 		public int Id { get; }

--- a/src/IdeaStatica.BimApiLink/Identifiers/StringIdentifier.cs
+++ b/src/IdeaStatica.BimApiLink/Identifiers/StringIdentifier.cs
@@ -2,16 +2,15 @@
 
 namespace IdeaStatica.BimApiLink.Identifiers
 {
-	public class StringIdentifier<T> : Identifier<T>
-			where T : IIdeaObject
-		{
+	public class StringIdentifier<T> : ImmutableIdentifier<T>
+		where T : IIdeaObject
+	{
 		public string Id { get; }
 
 		public StringIdentifier(string id)
+			: base(typeof(T).FullName + "-" + id)
 		{
 			Id = id;
 		}
-
-		public override string GetStringId() => typeof(T).FullName + "-" + Id;
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Identifiers/StringIdentifier.cs
+++ b/src/IdeaStatica.BimApiLink/Identifiers/StringIdentifier.cs
@@ -2,9 +2,9 @@
 
 namespace IdeaStatica.BimApiLink.Identifiers
 {
-	public record StringIdentifier<T> : Identifier<T>
-		where T : IIdeaObject
-	{
+	public class StringIdentifier<T> : Identifier<T>
+			where T : IIdeaObject
+		{
 		public string Id { get; }
 
 		public StringIdentifier(string id)

--- a/src/IdeaStatica.BimApiLink/Importers/AbstractImporter.cs
+++ b/src/IdeaStatica.BimApiLink/Importers/AbstractImporter.cs
@@ -1,27 +1,28 @@
 ﻿using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
+using System;
 
 namespace IdeaStatica.BimApiLink.Importers
 {
 	public abstract class AbstractImporter<T> : BimLinkObject, IImporter<T>
 		where T : IIdeaObject
 	{
-		public TObj? Create<TObj>(Identifier<TObj> identifier)
+		public TObj Create<TObj>(Identifier<TObj> identifier)
 			where TObj : IIdeaObject
 		{
-			if (identifier is not Identifier<T> id)
+			if (!(identifier is Identifier<T> id))
 			{
 				throw new ArgumentException();
 			}
 
-			T? obj = Create(id);
+			T obj = Create(id);
 
-			if (obj is null)
+			if (obj == null)
 			{
 				return default;
 			}
 
-			if (obj is not TObj res)
+			if (!(obj is TObj res))
 			{
 				throw new ArgumentException();
 			}
@@ -29,7 +30,7 @@ namespace IdeaStatica.BimApiLink.Importers
 			return res;
 		}
 
-		public IIdeaObject? Create(IIdentifier identifier)
+		public IIdeaObject Create(IIdentifier identifier)
 		{
 			if (identifier is Identifier<T> id)
 			{
@@ -39,6 +40,6 @@ namespace IdeaStatica.BimApiLink.Importers
 			throw new ArgumentException();
 		}
 
-		public abstract T? Create(Identifier<T> identifier);
+		public abstract T Create(Identifier<T> identifier);
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Importers/IBimApiImporter.cs
+++ b/src/IdeaStatica.BimApiLink/Importers/IBimApiImporter.cs
@@ -5,8 +5,8 @@ namespace IdeaStatica.BimApiLink.Importers
 {
 	public interface IBimApiImporter
 	{
-		T? Get<T>(Identifier<T> identifier) where T : IIdeaObject;
+		T Get<T>(Identifier<T> identifier) where T : IIdeaObject;
 
-		IIdeaObject? Get(IIdentifier identifier);
+		IIdeaObject Get(IIdentifier identifier);
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Importers/IImporter.cs
+++ b/src/IdeaStatica.BimApiLink/Importers/IImporter.cs
@@ -5,15 +5,15 @@ namespace IdeaStatica.BimApiLink.Importers
 {
 	public interface IImporter
 	{
-		T? Create<T>(Identifier<T> identifier)
+		T Create<T>(Identifier<T> identifier)
 			where T : IIdeaObject;
 
-		IIdeaObject? Create(IIdentifier identifier);
+		IIdeaObject Create(IIdentifier identifier);
 	}
 
 	public interface IImporter<T> : IImporter
 		where T : IIdeaObject
 	{
-		T? Create(Identifier<T> identifier);
+		T Create(Identifier<T> identifier);
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Importers/IImporterProvider.cs
+++ b/src/IdeaStatica.BimApiLink/Importers/IImporterProvider.cs
@@ -1,7 +1,9 @@
-﻿namespace IdeaStatica.BimApiLink.Importers
+﻿using System;
+
+namespace IdeaStatica.BimApiLink.Importers
 {
 	public interface IImporterProvider
 	{
-		IImporter? GetProvider(Type type);
+		IImporter GetProvider(Type type);
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Importers/ImporterDispatcher.cs
+++ b/src/IdeaStatica.BimApiLink/Importers/ImporterDispatcher.cs
@@ -1,12 +1,15 @@
 ﻿using IdeaStatica.BimApiLink.Hooks;
 using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IdeaStatica.BimApiLink.Importers
 {
 	internal class ImporterDispatcher : IBimApiImporter
 	{
-		private readonly Dictionary<Type, int> _interfaceRank = new();
+		private readonly Dictionary<Type, int> _interfaceRank = new Dictionary<Type, int>();
 		private readonly ImporterManager _importerManager;
 		private readonly IImporterHook _importerHookManager;
 
@@ -19,14 +22,14 @@ namespace IdeaStatica.BimApiLink.Importers
 			_interfaceRank[typeof(IIdeaObjectWithResults)] = 0;
 		}
 
-		public T? Get<T>(Identifier<T> identifier)
+		public T Get<T>(Identifier<T> identifier)
 			where T : IIdeaObject
 		{
-			foreach (Type? type in GetSortedInterfaces(typeof(T)))
+			foreach (Type type in GetSortedInterfaces(typeof(T)))
 			{
-				if (_importerManager.TryResolve(type, out IImporter? importer))
+				if (_importerManager.TryResolve(type, out IImporter importer))
 				{
-					T? obj;
+					T obj;
 
 					_importerHookManager.EnterCreate(identifier);
 					try
@@ -47,13 +50,13 @@ namespace IdeaStatica.BimApiLink.Importers
 			throw new ArgumentException();
 		}
 
-		public IIdeaObject? Get(IIdentifier identifier)
+		public IIdeaObject Get(IIdentifier identifier)
 		{
-			foreach (Type? type in GetSortedInterfaces(identifier.ObjectType))
+			foreach (Type type in GetSortedInterfaces(identifier.ObjectType))
 			{
-				if (_importerManager.TryResolve(type, out IImporter? importer))
+				if (_importerManager.TryResolve(type, out IImporter importer))
 				{
-					IIdeaObject? obj;
+					IIdeaObject obj;
 
 					_importerHookManager.EnterCreate(identifier);
 					try
@@ -97,7 +100,7 @@ namespace IdeaStatica.BimApiLink.Importers
 
 		private int GetInterfaceRankInternal(Type type)
 		{
-			Type[]? interfaces = type.GetInterfaces();
+			Type[] interfaces = type.GetInterfaces();
 
 			if (interfaces.Length == 0)
 			{

--- a/src/IdeaStatica.BimApiLink/Importers/ImporterManager.cs
+++ b/src/IdeaStatica.BimApiLink/Importers/ImporterManager.cs
@@ -1,21 +1,22 @@
 ﻿using IdeaStatiCa.BimApi;
-using System.Diagnostics.CodeAnalysis;
+using System;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.Importers
 {
 	internal class ImporterManager
 	{
-		private readonly Dictionary<Type, IImporter> _importers = new();
-		private readonly List<IImporterProvider> _providers = new();
+		private readonly Dictionary<Type, IImporter> _importers = new Dictionary<Type, IImporter>();
+		private readonly List<IImporterProvider> _providers = new List<IImporterProvider>();
 
 		public void RegisterImporter<T>(IImporter<T> importer)
 			where T : IIdeaObject => _importers.Add(typeof(T), importer);
 
 		public void RegisterProvider(IImporterProvider provider) => _providers.Add(provider);
 
-		public bool TryResolve(Type type, [NotNullWhen(true)] out IImporter? importer)
+		public bool TryResolve(Type type, out IImporter importer)
 		{
-			if (_importers.TryGetValue(type, out IImporter? importer1))
+			if (_importers.TryGetValue(type, out IImporter importer1))
 			{
 				importer = importer1;
 				return true;
@@ -24,7 +25,7 @@ namespace IdeaStatica.BimApiLink.Importers
 			foreach (IImporterProvider provider in _providers)
 			{
 				importer = provider.GetProvider(type);
-				if (importer is not null)
+				if (!(importer is null))
 				{
 					return true;
 				}

--- a/src/IdeaStatica.BimApiLink/Importers/IntIdentifierImporter.cs
+++ b/src/IdeaStatica.BimApiLink/Importers/IntIdentifierImporter.cs
@@ -6,11 +6,11 @@ namespace IdeaStatica.BimApiLink.Importers
 	public abstract class IntIdentifierImporter<T> : AbstractImporter<T>
 		where T : IIdeaObject
 	{
-		public override T? Create(Identifier<T> identifier)
+		public override T Create(Identifier<T> identifier)
 		{
 			return Create(((IntIdentifier<T>)identifier).Id);
 		}
 
-		public abstract T? Create(int id);
+		public abstract T Create(int id);
 	}
 }

--- a/src/IdeaStatica.BimApiLink/ImportersConfiguration.cs
+++ b/src/IdeaStatica.BimApiLink/ImportersConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using IdeaStatica.BimApiLink.Hooks;
 using IdeaStatica.BimApiLink.Importers;
 using IdeaStatiCa.BimApi;
+using System;
 
 namespace IdeaStatica.BimApiLink
 {
@@ -44,7 +45,7 @@ namespace IdeaStatica.BimApiLink
 				_factory = factory;
 			}
 
-			public IImporter? GetProvider(Type type)
+			public IImporter GetProvider(Type type)
 			{
 				if (type != typeof(T))
 				{
@@ -64,10 +65,10 @@ namespace IdeaStatica.BimApiLink
 				_serviceProvider = serviceProvider;
 			}
 
-			public IImporter? GetProvider(Type type)
+			public IImporter GetProvider(Type type)
 			{
 				Type providerType = typeof(IImporter<>).MakeGenericType(type);
-				return (IImporter?)_serviceProvider.GetService(providerType);
+				return (IImporter)_serviceProvider.GetService(providerType);
 			}
 		}
 	}

--- a/src/IdeaStatica.BimApiLink/Persistence/ProjectStorage.cs
+++ b/src/IdeaStatica.BimApiLink/Persistence/ProjectStorage.cs
@@ -1,4 +1,5 @@
 ﻿using IdeaStatiCa.BimImporter.Persistence;
+using System.IO;
 
 namespace IdeaStatica.BimApiLink.Persistence
 {
@@ -17,20 +18,22 @@ namespace IdeaStatica.BimApiLink.Persistence
 
 		public void Save()
 		{
-			using FileStream fs = File.OpenWrite(_path);
-			using StreamWriter streamWriter = new(fs);
-
-			_filePersistence.Save(streamWriter);
+			using (FileStream fs = File.OpenWrite(_path))
+			using (StreamWriter streamWriter = new StreamWriter(fs))
+			{
+				_filePersistence.Save(streamWriter);
+			}
 		}
 
 		public void Load()
 		{
 			if (File.Exists(_path))
 			{
-				using FileStream fs = File.OpenRead(_path);
-				using StreamReader streamReader = new(fs);
-
-				_filePersistence.Load(streamReader);
+				using (FileStream fs = File.OpenRead(_path))
+				using (StreamReader streamReader = new StreamReader(fs))
+				{
+					_filePersistence.Load(streamReader);
+				}
 			}
 		}
 

--- a/src/IdeaStatica.BimApiLink/Plugin/BimApiApplication.cs
+++ b/src/IdeaStatica.BimApiLink/Plugin/BimApiApplication.cs
@@ -7,6 +7,8 @@ using IdeaStatica.BimApiLink.Scoping;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimImporter;
 using IdeaStatiCa.Plugin;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IdeaStatica.BimApiLink
 {
@@ -112,7 +114,7 @@ namespace IdeaStatica.BimApiLink
 
 		private BimLinkScope CreateScope(CountryCode countryCode)
 		{
-			object? userData = _userDataSource.GetUserData();
+			object userData = _userDataSource.GetUserData();
 
 			return new BimLinkScope(new BimApiImporterCacheAdapter(_bimApiImporter), countryCode, userData);
 		}

--- a/src/IdeaStatica.BimApiLink/Plugin/FeaApplication.cs
+++ b/src/IdeaStatica.BimApiLink/Plugin/FeaApplication.cs
@@ -6,6 +6,8 @@ using IdeaStatica.BimApiLink.Persistence;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimImporter;
 using IdeaStatiCa.Plugin;
+using System;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.Plugin
 {

--- a/src/IdeaStatica.BimApiLink/Plugin/FeaModel.cs
+++ b/src/IdeaStatica.BimApiLink/Plugin/FeaModel.cs
@@ -3,18 +3,21 @@ using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatica.BimApiLink.Importers;
 using IdeaStatiCa.BimApi;
 using Nito.Disposables.Internals;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IdeaStatica.BimApiLink.Plugin
 {
 	public class FeaUserSelection
 	{
-		public ICollection<Identifier<IIdeaNode>> Nodes { get; init; }
+		public ICollection<Identifier<IIdeaNode>> Nodes { get; set; }
 			= Array.Empty<Identifier<IIdeaNode>>();
 
-		public ICollection<Identifier<IIdeaMember1D>> Members { get; init; }
+		public ICollection<Identifier<IIdeaMember1D>> Members { get; set; }
 			= Array.Empty<Identifier<IIdeaMember1D>>();
 
-		public ICollection<Identifier<IIdeaCombiInput>> Combinations { get; init; }
+		public ICollection<Identifier<IIdeaCombiInput>> Combinations { get; set; }
 			= Array.Empty<Identifier<IIdeaCombiInput>>();
 	}
 
@@ -29,7 +32,7 @@ namespace IdeaStatica.BimApiLink.Plugin
 
 	internal class FeaModelAdapter : IIdeaModel
 	{
-		private FeaUserSelection? _lastSelection;
+		private FeaUserSelection _lastSelection;
 
 		private readonly IBimApiImporter _bimApiImporter;
 		private readonly IFeaModel _feaModel;

--- a/src/IdeaStatica.BimApiLink/Plugin/PluginExtension.cs
+++ b/src/IdeaStatica.BimApiLink/Plugin/PluginExtension.cs
@@ -1,6 +1,7 @@
 ﻿using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimImporter;
+using System;
 
 namespace IdeaStatica.BimApiLink.Plugin
 {

--- a/src/IdeaStatica.BimApiLink/Plugin/ProjectAdapter.cs
+++ b/src/IdeaStatica.BimApiLink/Plugin/ProjectAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using IdeaStatica.BimApiLink.Importers;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimImporter;
+using System;
 
 namespace IdeaStatica.BimApiLink.Plugin
 {
@@ -20,7 +21,7 @@ namespace IdeaStatica.BimApiLink.Plugin
 
 		public IIdeaObject GetBimObject(int id)
 		{
-			IIdeaObject? obj = _bimApiImporter.Get(_project.GetIdentifier(id));
+			IIdeaObject obj = _bimApiImporter.Get(_project.GetIdentifier(id));
 			if (obj is null)
 			{
 				throw new InvalidOperationException();

--- a/src/IdeaStatica.BimApiLink/Results/BimApi/IdeaResult.cs
+++ b/src/IdeaStatica.BimApiLink/Results/BimApi/IdeaResult.cs
@@ -1,5 +1,6 @@
 ﻿using IdeaRS.OpenModel.Result;
 using IdeaStatiCa.BimApi.Results;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.Results.BimApi
 {
@@ -9,7 +10,7 @@ namespace IdeaStatica.BimApiLink.Results.BimApi
 
 		public IEnumerable<IIdeaSection> Sections => _sections;
 
-		private readonly List<IIdeaSection> _sections = new();
+		private readonly List<IIdeaSection> _sections = new List<IIdeaSection>();
 
 		public IdeaResult(ResultLocalSystemType coordinateSystemType)
 		{

--- a/src/IdeaStatica.BimApiLink/Results/BimApi/IdeaSection.cs
+++ b/src/IdeaStatica.BimApiLink/Results/BimApi/IdeaSection.cs
@@ -1,5 +1,6 @@
 ﻿using IdeaStatiCa.BimApi.Results;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.Results.BimApi
 {
@@ -9,7 +10,7 @@ namespace IdeaStatica.BimApiLink.Results.BimApi
 
 		public IEnumerable<IIdeaSectionResult> Results => _results;
 
-		private readonly ConcurrentBag<IIdeaSectionResult> _results = new();
+		private readonly ConcurrentBag<IIdeaSectionResult> _results = new ConcurrentBag<IIdeaSectionResult>();
 
 		public IdeaSection(double position)
 		{

--- a/src/IdeaStatica.BimApiLink/Results/BimResultsProviderAdapter.cs
+++ b/src/IdeaStatica.BimApiLink/Results/BimResultsProviderAdapter.cs
@@ -1,11 +1,12 @@
 ﻿using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimImporter.Results;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.Results
 {
 	internal class BimResultsProviderAdapter : IBimResultsProvider
 	{
-		private readonly List<IBimResultsProvider> _bimResultsProviders = new();
+		private readonly List<IBimResultsProvider> _bimResultsProviders = new List<IBimResultsProvider>();
 
 		public void RegisterImporter<T>(IInternalForcesImporter<T> importer)
 			where T : IIdeaObjectWithResults

--- a/src/IdeaStatica.BimApiLink/Results/IInternalForcesImporter.cs
+++ b/src/IdeaStatica.BimApiLink/Results/IInternalForcesImporter.cs
@@ -1,5 +1,5 @@
-﻿using IdeaStatica.BimApiLink.Identifiers;
-using IdeaStatiCa.BimApi;
+﻿using IdeaStatiCa.BimApi;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.Results
 {

--- a/src/IdeaStatica.BimApiLink/Results/IResultsImporter.cs
+++ b/src/IdeaStatica.BimApiLink/Results/IResultsImporter.cs
@@ -3,6 +3,20 @@ using IdeaStatiCa.BimApi.Results;
 
 namespace IdeaStatica.BimApiLink.Results
 {
+#if NET6_0
 	public record ResultsData<T>(T Object, IIdeaResult Results)
 		where T : IIdeaObjectWithResults;
+#else
+	public class ResultsData<T> where T : IIdeaObjectWithResults
+	{
+		public ResultsData(T @object, IIdeaResult results)
+		{
+			Object = @object;
+			Results = results;
+		}
+
+		public T Object { get; }
+		public IIdeaResult Results { get; }
+	}
+#endif
 }

--- a/src/IdeaStatica.BimApiLink/Results/InternalForcesBuilder.cs
+++ b/src/IdeaStatica.BimApiLink/Results/InternalForcesBuilder.cs
@@ -13,16 +13,18 @@ namespace IdeaStatica.BimApiLink.Results
 	{
 		private readonly ResultLocalSystemType _resultLocalSystem;
 		private readonly Dictionary<string, IdeaResult> _results = new Dictionary<string, IdeaResult>();
-		private readonly HashSet<ResultsData<T>> _resultsData = new HashSet<ResultsData<T>>();
+		private readonly List<ResultsData<T>> _resultsData = new List<ResultsData<T>>();
 
 		public InternalForcesBuilder(ResultLocalSystemType resultLocalSystem)
 		{
 			_resultLocalSystem = resultLocalSystem;
 		}
 
-		public Sections For(T obj, Identifier<IIdeaLoadCase> loadCaseIdentifier) => For(obj, Get(loadCaseIdentifier));
+		public Sections For(T obj, Identifier<IIdeaLoadCase> loadCaseIdentifier) 
+			=> For(obj, Get(loadCaseIdentifier));
 
-		public Sections For(Identifier<T> objIdentifier, IIdeaLoadCase loadCase) => For(Get(objIdentifier), loadCase);
+		public Sections For(Identifier<T> objIdentifier, IIdeaLoadCase loadCase) 
+			=> For(Get(objIdentifier), loadCase);
 
 		public Sections For(T obj, IIdeaLoadCase loadCase)
 		{

--- a/src/IdeaStatica.BimApiLink/Results/InternalForcesBuilder.cs
+++ b/src/IdeaStatica.BimApiLink/Results/InternalForcesBuilder.cs
@@ -4,6 +4,7 @@ using IdeaStatica.BimApiLink.Results.BimApi;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimApi.Results;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.Results
 {
@@ -11,8 +12,8 @@ namespace IdeaStatica.BimApiLink.Results
 		where T : IIdeaObjectWithResults
 	{
 		private readonly ResultLocalSystemType _resultLocalSystem;
-		private readonly Dictionary<string, IdeaResult> _results = new();
-		private readonly HashSet<ResultsData<T>> _resultsData = new();
+		private readonly Dictionary<string, IdeaResult> _results = new Dictionary<string, IdeaResult>();
+		private readonly HashSet<ResultsData<T>> _resultsData = new HashSet<ResultsData<T>>();
 
 		public InternalForcesBuilder(ResultLocalSystemType resultLocalSystem)
 		{
@@ -25,9 +26,9 @@ namespace IdeaStatica.BimApiLink.Results
 
 		public Sections For(T obj, IIdeaLoadCase loadCase)
 		{
-			if (!_results.TryGetValue(obj.Id, out IdeaResult? result))
+			if (!_results.TryGetValue(obj.Id, out IdeaResult result))
 			{
-				result = new(_resultLocalSystem);
+				result = new IdeaResult(_resultLocalSystem);
 				_results.Add(obj.Id, result);
 			}
 
@@ -44,7 +45,7 @@ namespace IdeaStatica.BimApiLink.Results
 			private readonly IIdeaLoadCase _loadCase;
 			private readonly IdeaResult _result;
 
-			private readonly Dictionary<double, IdeaSection> _sections = new();
+			private readonly Dictionary<double, IdeaSection> _sections = new Dictionary<double, IdeaSection>();
 
 
 			internal Sections(IIdeaLoadCase loadCase, IdeaResult result)
@@ -55,7 +56,7 @@ namespace IdeaStatica.BimApiLink.Results
 
 			public Sections Add(double position, double n, double qy, double qz, double mx, double my, double mz)
 			{
-				InternalForcesData data = new()
+				InternalForcesData data = new InternalForcesData()
 				{
 					N = n,
 					Qy = qy,
@@ -72,9 +73,9 @@ namespace IdeaStatica.BimApiLink.Results
 
 			private IdeaSection GetSection(double position)
 			{
-				if (!_sections.TryGetValue(position, out IdeaSection? section))
+				if (!_sections.TryGetValue(position, out IdeaSection section))
 				{
-					section = new(position);
+					section = new IdeaSection(position);
 					_sections.Add(position, section);
 					_result.Add(section);
 				}

--- a/src/IdeaStatica.BimApiLink/Results/InternalForcesImporterAdapter.cs
+++ b/src/IdeaStatica.BimApiLink/Results/InternalForcesImporterAdapter.cs
@@ -2,6 +2,8 @@
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimImporter.Results;
 using Nito.Disposables.Internals;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace IdeaStatica.BimApiLink.Results
 {
@@ -17,12 +19,12 @@ namespace IdeaStatica.BimApiLink.Results
 
 		public IEnumerable<ResultsData> GetResults(IEnumerable<IIdeaObjectWithResults> objects)
 		{
-			return _internalForcesImporter.GetResults(objects.OfType<T>().ToList())
+			return _internalForcesImporter.GetResults(objects.OfType<T>().ToArray())
 				.Select(Convert)
 				.WhereNotNull();
 		}
 
-		private ResultsData? Convert(ResultsData<T> resultsData)
+		private ResultsData Convert(ResultsData<T> resultsData)
 		{
 			MemberType? memberType = GetMemberType(resultsData.Object);
 			if (memberType is null)
@@ -36,11 +38,14 @@ namespace IdeaStatica.BimApiLink.Results
 				new[] { resultsData.Results });
 		}
 
-		private static MemberType? GetMemberType(T obj) => obj switch
+		private static MemberType? GetMemberType(T obj)
 		{
-			IIdeaMember1D => MemberType.Member1D,
-			IIdeaElement1D => MemberType.Element1D,
-			_ => null,
-		};
+			switch (obj)
+			{
+				case IIdeaMember1D _: return MemberType.Member1D;
+				case IIdeaElement1D _: return MemberType.Element1D;
+				default: return null;
+			}
+		}
 	}
 }

--- a/src/IdeaStatica.BimApiLink/Results/ResultsData.cs
+++ b/src/IdeaStatica.BimApiLink/Results/ResultsData.cs
@@ -7,16 +7,19 @@ namespace IdeaStatica.BimApiLink.Results
 	public record ResultsData<T>(T Object, IIdeaResult Results)
 		where T : IIdeaObjectWithResults;
 #else
-	public class ResultsData<T> where T : IIdeaObjectWithResults
+
+	public class ResultsData<T>
+		where T : IIdeaObjectWithResults
 	{
+		public T Object { get; }
+		public IIdeaResult Results { get; }
+
 		public ResultsData(T @object, IIdeaResult results)
 		{
 			Object = @object;
 			Results = results;
 		}
-
-		public T Object { get; }
-		public IIdeaResult Results { get; }
 	}
+
 #endif
 }

--- a/src/IdeaStatica.BimApiLink/ResultsImportersConfiguration.cs
+++ b/src/IdeaStatica.BimApiLink/ResultsImportersConfiguration.cs
@@ -8,7 +8,7 @@ namespace IdeaStatica.BimApiLink
 	{
 		public IBimResultsProvider ResultsProvider => _adapter;
 
-		private readonly BimResultsProviderAdapter _adapter = new();
+		private readonly BimResultsProviderAdapter _adapter = new BimResultsProviderAdapter();
 
 		public ResultsImportersConfiguration RegisterImporter<T>(IInternalForcesImporter<T> importer)
 			where T : IIdeaObjectWithResults

--- a/src/IdeaStatica.BimApiLink/Scoping/BimApiImporterCacheAdapter.cs
+++ b/src/IdeaStatica.BimApiLink/Scoping/BimApiImporterCacheAdapter.cs
@@ -1,12 +1,13 @@
 ﻿using IdeaStatica.BimApiLink.Identifiers;
 using IdeaStatica.BimApiLink.Importers;
 using IdeaStatiCa.BimApi;
+using System.Collections.Generic;
 
 namespace IdeaStatica.BimApiLink.Scoping
 {
 	internal class BimApiImporterCacheAdapter : IBimApiImporter
 	{
-		private readonly Dictionary<IIdentifier, IIdeaObject?> _importedObjects = new();
+		private readonly Dictionary<IIdentifier, IIdeaObject> _importedObjects = new Dictionary<IIdentifier, IIdeaObject>();
 
 		private readonly IBimApiImporter _bimApiImporter;
 
@@ -15,29 +16,29 @@ namespace IdeaStatica.BimApiLink.Scoping
 			_bimApiImporter = bimApiImporter;
 		}
 
-		public T? Get<T>(Identifier<T> identifier)
+		public T Get<T>(Identifier<T> identifier)
 			where T : IIdeaObject
 		{
-			if (_importedObjects.TryGetValue(identifier, out IIdeaObject? obj)
+			if (_importedObjects.TryGetValue(identifier, out IIdeaObject obj)
 				&& obj is T storedObj)
 			{
 				return storedObj;
 			}
 
-			T? newObj = _bimApiImporter.Get(identifier);
+			T newObj = _bimApiImporter.Get(identifier);
 			_importedObjects[identifier] = newObj;
 
 			return newObj;
 		}
 
-		public IIdeaObject? Get(IIdentifier identifier)
+		public IIdeaObject Get(IIdentifier identifier)
 		{
-			if (_importedObjects.TryGetValue(identifier, out IIdeaObject? obj))
+			if (_importedObjects.TryGetValue(identifier, out IIdeaObject obj))
 			{
 				return obj;
 			}
 
-			IIdeaObject? newObj = _bimApiImporter.Get(identifier);
+			IIdeaObject newObj = _bimApiImporter.Get(identifier);
 			_importedObjects[identifier] = newObj;
 
 			return newObj;

--- a/src/IdeaStatica.BimApiLink/Scoping/BimLinkScope.cs
+++ b/src/IdeaStatica.BimApiLink/Scoping/BimLinkScope.cs
@@ -1,20 +1,22 @@
 ﻿using IdeaRS.OpenModel;
 using IdeaStatica.BimApiLink.Importers;
+using System;
+using System.Threading;
 
 namespace IdeaStatica.BimApiLink.Scoping
 {
 	public class BimLinkScope : IScope, IDisposable
 	{
-		private static readonly AsyncLocal<BimLinkScope?> _current = new();
+		private static readonly AsyncLocal<BimLinkScope> _current = new AsyncLocal<BimLinkScope>();
 		internal static BimLinkScope Current => _current.Value ?? throw new InvalidOperationException();
 
 		public IBimApiImporter BimApiImporter { get; }
 
 		public CountryCode CountryCode { get; }
 
-		public object? UserData { get; }
+		public object UserData { get; }
 
-		public BimLinkScope(IBimApiImporter bimApiImporter, CountryCode countryCode, object? userData)
+		public BimLinkScope(IBimApiImporter bimApiImporter, CountryCode countryCode, object userData)
 		{
 			BimApiImporter = bimApiImporter;
 			CountryCode = countryCode;

--- a/src/IdeaStatica.BimApiLink/Scoping/IScope.cs
+++ b/src/IdeaStatica.BimApiLink/Scoping/IScope.cs
@@ -9,6 +9,6 @@ namespace IdeaStatica.BimApiLink.Scoping
 
 		CountryCode CountryCode { get; }
 
-		object? UserData { get; }
+		object UserData { get; }
 	}
 }


### PR DESCRIPTION
Migrate BimApiLink to the multitarget net48 and net6.0.
Migrate BimApiLinkFeaExample to the netstandard2.0.
Migrate BimApiLinkExample to the multitarget net48 and net6.0.