### PR TITLE
Disposing xmlwrite bugfix

### DIFF
--- a/src/IdeaRS.OpenModel/Tools.cs
+++ b/src/IdeaRS.OpenModel/Tools.cs
@@ -91,8 +91,10 @@ namespace IdeaRS.OpenModel
 		/// <returns>Serialize model in string</returns>
 		public static void SerializeModelToFile<T>(T model, string filePath)
 		{
-			XmlWriter writer = XmlWriter.Create(filePath, GetWriterSettings());
-			SerializeModel(model, writer);
+			using (XmlWriter writer = XmlWriter.Create(filePath, GetWriterSettings()))
+			{
+				SerializeModel(model, writer);
+			}	
 		}
 
 		/// <summary>

--- a/src/IdeaStatiCa.Plugin/Grpc/AutomationHostingGrpc.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/AutomationHostingGrpc.cs
@@ -1,4 +1,5 @@
-﻿using IdeaStatiCa.Plugin.Grpc;
+﻿using IdeaStatica.Communication;
+using IdeaStatiCa.Plugin.Grpc;
 using IdeaStatiCa.Plugin.Grpc.Reflection;
 using Nito.AsyncEx.Synchronous;
 using System;
@@ -11,7 +12,7 @@ namespace IdeaStatiCa.Plugin
 	/// <summary>
 	/// Grpc Hosting implementation of <see cref="AutomationHosting{MyInterface, ClientInterface}"/>
 	/// </summary>
-	public class AutomationHostingGrpc<MyInterface, ClientInterface> : IBIMPluginClient<ClientInterface>, IDisposable where MyInterface : class where ClientInterface : class
+	public class AutomationHostingGrpc<MyInterface, ClientInterface> : IGrpcCommunicationCommonInterface, IBIMPluginClient<ClientInterface>, IDisposable where MyInterface : class where ClientInterface : class
 	{
 		private Task hostingTask;
 		private CancellationTokenSource tokenSource;

--- a/src/IdeaStatiCa.Plugin/Grpc/IGrpcCommunicationCommonInterface.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/IGrpcCommunicationCommonInterface.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace IdeaStatica.Communication
+{
+	public interface IGrpcCommunicationCommonInterface
+	{
+		Task RunAsync(string id);
+	}
+}


### PR DESCRIPTION
disposing of xmlwriter - created file remained blocked by xmlwriter and an attempt to open it crashed with "file is being used by another process" error