### PR TITLE
#13714 IProgressCallback.ExceptionMessage uses the Exception type instead of string to preserve the error details

### DIFF
--- a/src/IdeaStatiCa.Plugin/IProgressCallback.cs
+++ b/src/IdeaStatiCa.Plugin/IProgressCallback.cs
@@ -1,4 +1,5 @@
-﻿using System.ServiceModel;
+﻿using System;
+using System.ServiceModel;
 
 namespace IdeaStatiCa.Plugin
 {
@@ -9,9 +10,9 @@ namespace IdeaStatiCa.Plugin
 		/// Method is called when an exception occurs on the server.
 		/// </summary>
 		/// <param name="function">Name of the method.</param>
-		/// <param name="message">Details of the exception</param>
+		/// <param name="exception">Details of the exception</param>
 		[OperationContract(IsOneWay = true)]
-		void ExceptionMessage(string function, string message);
+		void ExceptionMessage(string function, Exception exception);
 
 		/// <summary>
 		/// infomation about progress of event.

--- a/src/IdeaStatiCa.Plugin/ProgressSender.cs
+++ b/src/IdeaStatiCa.Plugin/ProgressSender.cs
@@ -11,9 +11,9 @@ namespace IdeaStatiCa.Plugin
 		{
 		}
 
-		public void ExceptionMessage(string function, string message)
+		public void ExceptionMessage(string function, Exception exception)
 		{
-			Service?.ExceptionMessage(function, message);
+			Service?.ExceptionMessage(function, exception);
 		}
 
 		public void ProgressMessage(double percent, string message)


### PR DESCRIPTION
IProgressCallback.ExceptionMessage used the string to accept the error details and only the Exception.Message could be passed to this call, however that prevented the full exception details including the exception type, stack trace, data or inner exceptions to be handled or used for diagnosing the problem. By using the Exception argument type the data can be fully used.