### PR TITLE
Refactor ConnectionController and ConnectionControllerGrpc

### DIFF
--- a/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/App.config
+++ b/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/App.config
@@ -11,7 +11,7 @@
     <applicationSettings>
         <ConnectionAutomationApp.Properties.Settings>
             <setting name="IdeaStatiCaDir" serializeAs="String">
-                <value>C:\Program Files\IDEA StatiCa\StatiCa 22.1</value>
+                <value>C:\Program Files\IDEA StatiCa\StatiCa 23.0</value>
             </setting>
         </ConnectionAutomationApp.Properties.Settings>
     </applicationSettings>

--- a/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/MainVM.cs
+++ b/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/MainVM.cs
@@ -11,7 +11,6 @@ namespace ConnectionAutomationApp
 	public class MainVM : INotifyPropertyChanged, IDisposable
 	{
 		bool isIdea;
-		bool useGrpcCommunication;
 		readonly string ideaStatiCaDir;
 		string statusMessage;
 		IConnectionController connectionController;
@@ -21,7 +20,6 @@ namespace ConnectionAutomationApp
 
 		public MainVM()
 		{
-			UseGrpcCommunication = true;
 			ideaStatiCaDir = Properties.Settings.Default.IdeaStatiCaDir;
 			if (Directory.Exists(ideaStatiCaDir))
 			{
@@ -57,17 +55,6 @@ namespace ConnectionAutomationApp
 			{
 				isIdea = value;
 				NotifyPropertyChanged("IsIdea");
-			}
-		}
-
-		public bool UseGrpcCommunication
-		{
-			get => useGrpcCommunication;
-
-			set
-			{
-				useGrpcCommunication = value;
-				NotifyPropertyChanged("UseGrpcCommunication");
 			}
 		}
 
@@ -142,14 +129,10 @@ namespace ConnectionAutomationApp
 
 		private void RunIdeaConnection(object obj)
 		{
-			if(UseGrpcCommunication)
-			{
-				this.ConnectionController = IdeaConnectionControllerGrpc.Create(ideaStatiCaDir, new NullLogger());
-			}
-			else
-			{
-				this.ConnectionController = IdeaConnectionController.Create(ideaStatiCaDir);
-			}
+			// IdeaConnectionControllerGrpc is obsolete controller.
+			// ConnectionController = IdeaConnectionControllerGrpc.Create(ideaStatiCaDir, new NullLogger());
+
+			ConnectionController = IdeaConnectionController.Create(ideaStatiCaDir);
 		}
 
 		private bool CanRunIdeaConnection(object arg)

--- a/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/MainWindow.xaml
+++ b/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/MainWindow.xaml
@@ -1,14 +1,13 @@
-﻿<Window x:Class="ConnectionAutomationApp.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:ConnectionAutomationApp"
-        mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800" Closed="Window_Closed">
+﻿<Window
+	x:Class="ConnectionAutomationApp.MainWindow"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Title="MainWindow" Height="450" Width="800" Closed="Window_Closed">
 	<DockPanel LastChildFill="True">
 		<ToolBar DockPanel.Dock="Top">
-			<CheckBox IsChecked="{Binding UseGrpcCommunication, Mode=TwoWay}">Use GRPC</CheckBox>
 			<Button Command="{Binding RunIdeaConnectionCmd, Mode=TwoWay}">Run IdeaConnection</Button>
 			<Button Command="{Binding OpenProjectCmd, Mode=TwoWay}">Open Project</Button>
 			<Button Command="{Binding CloseProjectCmd, Mode=TwoWay}">Close Project</Button>

--- a/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/Properties/Settings.Designer.cs
+++ b/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ConnectionAutomationApp.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -25,7 +25,7 @@ namespace ConnectionAutomationApp.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("C:\\Program Files\\IDEA StatiCa\\StatiCa 22.1")]
+        [global::System.Configuration.DefaultSettingValueAttribute("C:\\Program Files\\IDEA StatiCa\\StatiCa 23.0")]
         public string IdeaStatiCaDir {
             get {
                 return ((string)(this["IdeaStatiCaDir"]));

--- a/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/Properties/Settings.settings
+++ b/src/Examples/ConnHiddenCalc/ConnectionAutomationApp/Properties/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="IdeaStatiCaDir" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">C:\Program Files\IDEA StatiCa\StatiCa 22.1</Value>
+      <Value Profile="(Default)">C:\Program Files\IDEA StatiCa\StatiCa 23.0</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/IdeaStatiCa.Plugin/IConnectionController.cs
+++ b/src/IdeaStatiCa.Plugin/IConnectionController.cs
@@ -2,15 +2,32 @@
 
 namespace IdeaStatiCa.Plugin
 {
+	/// <summary>
+	/// Provides opening of project with UI (opens IDEA StatiCa Connection application).
+	/// </summary>
 	public interface IConnectionController
 	{
+		/// <summary>
+		/// Fires when connection application exited.
+		/// </summary>
 		event EventHandler ConnectionAppExited;
 
+		/// <summary>
+		/// Indicates whether communication (open/close project) is alive.
+		/// </summary>
 		bool IsConnected { get; }
 
+		/// <summary>
+		/// Opens connection file project, provided service is connected.
+		/// </summary>
+		/// <param name="fileName">The file path to the ideaCon.</param>
+		/// <returns></returns>
 		int OpenProject(string fileName);
 
+		/// <summary>
+		/// Close connection file project, provided service is connected and connection file is opened.
+		/// </summary>
+		/// <returns></returns>
 		int CloseProject();
-
 	}
 }

--- a/src/IdeaStatiCa.Plugin/IdeaConnectionControllerGrpc.cs
+++ b/src/IdeaStatiCa.Plugin/IdeaConnectionControllerGrpc.cs
@@ -1,168 +1,26 @@
-﻿using IdeaStatiCa.Plugin.Grpc;
-using IdeaStatiCa.Plugin.Utilities;
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Threading;
+﻿using System;
 
 namespace IdeaStatiCa.Plugin
 {
-	public class IdeaConnectionControllerGrpc : IDisposable, IConnectionController
+	[Obsolete("This class will be replaced by IdeaConnectionController controller.")]
+	public class IdeaConnectionControllerGrpc : IdeaConnectionController
 	{
-		private readonly string IdeaInstallDir;
-		private Process IdeaStatiCaProcess { get; set; }
-		private Uri CalculatorUrl { get; set; }
-
-		public event EventHandler ConnectionAppExited;
-
-		private int GrpcPort { get; set; }
-
-		private IPluginLogger Logger { get; set; }
-
-		protected EventWaitHandle CurrentItemChangedEvent;
-
-		//protected IdeaStatiCaClient<IAutomation> ConnectionAppClient { get; set; }
-
-		protected AutomationHostingGrpc<IAutomation, IAutomation> GrpcClient { get; set; }
-
-		protected virtual uint UserMode { get; } = 0;
-
-		private string BaseAddress { get; set; }
-
-		bool IConnectionController.IsConnected => GrpcClient?.IsConnected == true;
-
-#if DEBUG
-		private int StartTimeout = -1;
-#else
-		int StartTimeout = 1000*20;
-#endif
-
-		private IdeaConnectionControllerGrpc(string ideaInstallDir, IPluginLogger logger)
+		private IdeaConnectionControllerGrpc(string ideaInstallDir, IPluginLogger logger) : base(ideaInstallDir, logger)
 		{
-			Logger = logger ?? new NullLogger();
-			if (!Directory.Exists(ideaInstallDir))
-			{
-				throw new ArgumentException($"IdeaConnectionController.IdeaConnectionController - directory '{ideaInstallDir}' doesn't exist");
-			}
-
-			IdeaInstallDir = ideaInstallDir;
 		}
 
-		public static IConnectionController Create(string ideaInstallDir, IPluginLogger logger)
+		/// <summary>
+		/// Creates connection and starts IDEA StatiCa connection application.
+		/// Call OpenProject after this method to open specific project.
+		/// </summary>
+		/// <param name="ideaInstallDir">IDEA StatiCa installation directory.</param>
+		/// <param name="logger">The logger.</param>
+		/// <returns>A controller object.</returns>
+		public new static IConnectionController Create(string ideaInstallDir, IPluginLogger logger)
 		{
 			IdeaConnectionControllerGrpc connectionController = new IdeaConnectionControllerGrpc(ideaInstallDir, logger);
 			connectionController.OpenConnectionClient();
 			return connectionController;
 		}
-
-		public int OpenProject(string fileName)
-		{
-			GrpcClient.MyBIM.OpenProject(fileName);
-			return 1;
-		}
-
-		public int CloseProject()
-		{
-			GrpcClient.MyBIM.CloseProject();
-			return 1;
-		}
-
-		private void OpenConnectionClient()
-		{
-			OpenConnectionClientGrpc();
-		}
-
-		private void OpenConnectionClientGrpc()
-		{
-			int processId = Process.GetCurrentProcess().Id;
-			GrpcPort = PortFinder.FindPort(Constants.MinGrpcPort, Constants.MaxGrpcPort);
-			string connChangedEventName = string.Format(Constants.ConnectionChangedEventFormat, processId);
-			CurrentItemChangedEvent = new EventWaitHandle(false, EventResetMode.AutoReset, connChangedEventName);
-
-			string applicationExePath = Path.Combine(IdeaInstallDir, Constants.IdeaConnectionAppName);
-
-			if (!File.Exists(applicationExePath))
-			{
-				throw new ArgumentException($"IdeaConnectionController.OpenConnectionClient - file '{applicationExePath}' doesn't exist");
-			}
-
-			Process connectionProc = new Process();
-			string eventName = string.Format("IdeaStatiCaEvent{0}", processId);
-			using (EventWaitHandle syncEvent = new EventWaitHandle(false, EventResetMode.AutoReset, eventName))
-			{
-				connectionProc.StartInfo = new ProcessStartInfo(applicationExePath, $"-cmd:automation-{processId} {IdeaStatiCa.Plugin.Constants.GrpcPortParam}:{GrpcPort} user-mode 192");
-				connectionProc.EnableRaisingEvents = true;
-				connectionProc.Start();
-
-				if (!syncEvent.WaitOne(StartTimeout))
-				{
-					throw new TimeoutException($"Time out - process '{applicationExePath}' doesn't set the event '{eventName}'");
-				}
-			}
-
-			IdeaStatiCaProcess = connectionProc;
-			var grpcClient = new GrpcClient(Logger);
-
-			var grpcClientTask = grpcClient.StartAsync(processId.ToString(), GrpcPort);
-
-			GrpcClient = new AutomationHostingGrpc<IAutomation, IAutomation>(null, grpcClient, Logger);
-			GrpcClient.RunAsync(processId.ToString());
-
-			IdeaStatiCaProcess.Exited += CalculatorProcess_Exited;
-		}
-
-		private void CalculatorProcess_Exited(object sender, EventArgs e)
-		{
-			if (IdeaStatiCaProcess == null)
-			{
-				return;
-			}
-
-			IdeaStatiCaProcess.Dispose();
-			IdeaStatiCaProcess = null;
-			CalculatorUrl = null;
-			//ConnectionAppClient = null;
-
-			if (ConnectionAppExited != null)
-			{
-				ConnectionAppExited(this, e);
-			}
-		}
-
-		#region IDisposable Support
-		private bool disposedValue = false; // To detect redundant calls
-
-		protected virtual void Dispose(bool disposing)
-		{
-			if (!disposedValue)
-			{
-				if (disposing)
-				{
-					// TODO: dispose managed state (managed objects).
-				}
-
-				// TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-				// TODO: set large fields to null.
-
-				disposedValue = true;
-			}
-		}
-
-		// TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-		// ~ConnectionControllerFactory()
-		// {
-		//   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-		//   Dispose(false);
-		// }
-
-		// This code added to correctly implement the disposable pattern.
-		public void Dispose()
-		{
-			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-			Dispose(true);
-			// TODO: uncomment the following line if the finalizer is overridden above.
-			// GC.SuppressFinalize(this);
-		}
-		#endregion
 	}
 }


### PR DESCRIPTION
Swap implementation in ConnectionController and ConnectionControllerGrpc (now ConnectionController uses gRPC communication)
Redirect ConnectionControllerGrpc to ConnectionController and mark it as Obsolete


