### PR TITLE
Logging exceptions from plugins to sentry

### DIFF
--- a/src/IdeaStatiCa.Plugin/Grpc/Reflection/GrpcMethodInvokerHandler.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/Reflection/GrpcMethodInvokerHandler.cs
@@ -174,8 +174,9 @@ namespace IdeaStatiCa.Plugin.Grpc.Reflection
 						Logger.LogWarning("GrpcMethodInvokerHandler.InvokeMethod - can not write arguments to log", ex);
 					}
 
+					var deserializeException = JsonConvert.DeserializeObject<Exception>(response.Data);
 
-					throw new ArgumentException(response.Data);
+					throw new ArgumentException(deserializeException.Message, deserializeException);
 				}
 
 				var responseData = JsonConvert.DeserializeObject(response.Data, returnType);

--- a/src/IdeaStatiCa.Plugin/Grpc/Reflection/GrpcReflectionMessageHandler.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/Reflection/GrpcReflectionMessageHandler.cs
@@ -70,7 +70,7 @@ namespace IdeaStatiCa.Plugin.Grpc.Reflection
 					OperationId = message.OperationId,
 					MessageType = GrpcMessage.Types.MessageType.Response,
 					MessageName = message.MessageName,
-					Data = e?.InnerException != null ? e.InnerException.Message : e.Message,
+					Data = e?.InnerException != null ? JsonConvert.SerializeObject(e.InnerException) : JsonConvert.SerializeObject(e),
 					DataType = typeof(Exception).Name
 				};
 

--- a/src/IdeaStatiCa.Plugin/Grpc/Reflection/GrpcReflectionServiceFactory.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/Reflection/GrpcReflectionServiceFactory.cs
@@ -80,10 +80,10 @@ namespace IdeaStatiCa.Plugin.Grpc
 				await Task.CompletedTask;
 				return methodInvoker.InvokeMethod<object>(method.Name, returnType, arguments);
 			}
-			catch(ArgumentException)
+			catch(ArgumentException e)
 			{
 				// rethrow exeption which were handled by a plugin
-				throw;
+				throw e.InnerException;
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
Serialize exception from plugin and send it via grpc message. Then deserialize it a rethrow it, so it can be log to sentry in Checkbot.

