### PR TITLE
Move blobStorageId and Content id from metadata to DataContent body

### DIFF
--- a/src/IdeaStatiCa.Plugin/Grpc/GrpcBlobStorageClient.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/GrpcBlobStorageClient.cs
@@ -58,13 +58,9 @@ namespace IdeaStatiCa.Plugin.Grpc
 			logger.LogDebug($"GrpcBlobStorageClient starts Write, blobStorageId: '{blobStorageId}', contentId: '{contentId}', content length in bytes: {content.Length}");
 			content.Seek(0, SeekOrigin.Begin);
 
-			var metadata = new Metadata();
-			metadata.Add(Constants.BlobStorageId, blobStorageId);
-			metadata.Add(Constants.ContentId, contentId);
-
 			try
 			{
-				using (var call = client.Write(metadata))
+				using (var call = client.Write())
 				{
 					var requestStream = call.RequestStream;
 					var buffer = new byte[chunkSize];
@@ -82,7 +78,9 @@ namespace IdeaStatiCa.Plugin.Grpc
 
 						await requestStream.WriteAsync(new ContentData()
 						{
-							Data = ByteString.CopyFrom(buffer)
+							Data = ByteString.CopyFrom(buffer),
+							BlobStorageId = blobStorageId,
+							ContentId = contentId
 						});
 
 						logger.LogTrace($"GrpcBlobStorageClient Write, blobStorageId: '{blobStorageId}', contentId: '{contentId}' sent {buffer.Length} bytes");

--- a/src/IdeaStatiCa.Plugin/Grpc/GrpcReflectionServiceContract.proto
+++ b/src/IdeaStatiCa.Plugin/Grpc/GrpcReflectionServiceContract.proto
@@ -35,6 +35,8 @@ message VoidResponse {}
 
 message ContentData {
     bytes data = 1;
+    string blobStorageId = 2;
+    string contentId = 3;
 }
 
 message ContentRequest {


### PR DESCRIPTION
* Did you find critical bug in our code?
* When FilePath is used in gRPC metadata and contains country specific characters (á, ř ...) it is replaced with ? and causes issues

* Did you fix anything?
* Both FilePath & ContentId is now used in request itself