### PR TITLE
Mark welding type in the russian steel setup as obsolete

### DIFF
--- a/src/IdeaRS.OpenModel/Setups/SteelSetupRUS.cs
+++ b/src/IdeaRS.OpenModel/Setups/SteelSetupRUS.cs
@@ -1,4 +1,6 @@
-﻿namespace IdeaRS.OpenModel
+﻿using System;
+
+namespace IdeaRS.OpenModel
 {
 	/// <summary>
 	/// Steel setup RUS class
@@ -38,6 +40,7 @@
 		/// <summary>
 		/// WeldingType
 		/// </summary>
+		[Obsolete("Moved to the welding electrodes properties")]
 		public WeldingTypeSNIP WeldingTypeSNIP { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
Mark welding type in the russian steel setup as obsolete because it is moved to the welding electrode properties

* Did you find critical bug in our code?
* No
* Did you fix anything?
* No

# Propose PULL Request then and we will examine it
