### PR TITLE
#15470: Removed unused int arguments from public GrpcServer ctor, causing Prism error

### DIFF
--- a/src/IdeaStatiCa.Plugin/Grpc/GrpcServer.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/GrpcServer.cs
@@ -45,7 +45,7 @@ namespace IdeaStatiCa.Plugin.Grpc
 			MaxDataLength = Constants.GRPC_MAX_MSG_SIZE;
 			this.chunkSize = Constants.GRPC_CHUNK_SIZE;
 			Host = "localhost";
-			GrpcService = new Services.GrpcService(Logger, MaxDataLength);
+			GrpcService = new Services.GrpcService(Logger);
 		}
 
 		/// <summary>
@@ -54,15 +54,13 @@ namespace IdeaStatiCa.Plugin.Grpc
 		/// <param name="logger">Logger</param>
 		/// <param name="grpcService"></param>
 		/// <param name="blobStorageProvider">Provider of blob storages</param>
-		/// <param name="maxDataLength">The maximal size of GrpcMessage.data in bytes in grpc message</param>
-		/// <param name="chunkSize">Size of one chunk in bytes for blob storage data transferring</param>
-		public GrpcServer(IPluginLogger logger, IGrpcService grpcService, IBlobStorageProvider blobStorageProvider, int maxDataLength = Constants.GRPC_MAX_MSG_SIZE, int chunkSize = Constants.GRPC_CHUNK_SIZE)
+		public GrpcServer(IPluginLogger logger, IGrpcService grpcService, IBlobStorageProvider blobStorageProvider)
 		{
 			Debug.Assert(logger != null);
 			this.Logger = logger;
 			this.blobStorageProvider = blobStorageProvider;
-			MaxDataLength = maxDataLength;
-			this.chunkSize = chunkSize;
+			MaxDataLength = Constants.GRPC_MAX_MSG_SIZE;
+			this.chunkSize = Constants.GRPC_CHUNK_SIZE;
 			Host = "localhost";
 			GrpcService = grpcService;
 		}

--- a/src/IdeaStatiCa.Plugin/Grpc/Reflection/GrpcReflectionServer.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/Reflection/GrpcReflectionServer.cs
@@ -15,8 +15,8 @@ namespace IdeaStatiCa.Plugin.Grpc.Reflection
 		/// <param name="blobStorageProvider">Provider of blob storages</param>
 		/// <param name="maxDataLength">The maximal size of GrpcMessage.data in bytes in grpc message</param>
 		/// <param name="chunkSize">Size of one chunk in bytes for blob storage data transferring</param>
-		public GrpcReflectionServer(object instance, IPluginLogger logger, IBlobStorageProvider blobStorageProvider, int maxDataLength = Constants.GRPC_MAX_MSG_SIZE, int chunkSize = Constants.GRPC_CHUNK_SIZE) :
-			base(logger, new Services.GrpcService(logger, maxDataLength), blobStorageProvider, maxDataLength, chunkSize)
+		public GrpcReflectionServer(object instance, IPluginLogger logger, IBlobStorageProvider blobStorageProvider) :
+			base(logger, new Services.GrpcService(logger), blobStorageProvider)
 		{
 			logger.LogDebug("GrpcReflectionServer");
 

--- a/src/IdeaStatiCa.Plugin/Grpc/Services/GrpcService.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/Services/GrpcService.cs
@@ -38,10 +38,10 @@ namespace IdeaStatiCa.Plugin.Grpc.Services
 		/// </summary>
 		/// <param name="logger">Logger</param>
 		/// <param name="maxDataLength">The maximal size of GrpcMessage.data in grpc message</param>
-		public GrpcService(IPluginLogger logger, int maxDataLength = Constants.GRPC_MAX_MSG_SIZE)
+		public GrpcService(IPluginLogger logger)
 		{
 			this.logger = logger;
-			MaxDataLength = maxDataLength;
+			MaxDataLength = Constants.GRPC_MAX_MSG_SIZE;
 			logger.LogInformation("Creating GrpcService");
 		}
 		#endregion


### PR DESCRIPTION
#15470: Removed unused int arguments from public GrpcServer ctor, causing Prism error