### PR TITLE
19332 Topology code

### DIFF
--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Descriptors/OpenButtonDescriptor.cs
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Descriptors/OpenButtonDescriptor.cs
@@ -1,0 +1,42 @@
+﻿namespace IdeaStatiCa.CheckbotPlugin.PluginList.Descriptors
+{
+	public sealed class OpenButtonDescriptor
+	{
+		/// <summary>
+		/// Action name.
+		/// </summary>
+		public string Name { get; }
+
+		/// <summary>
+		/// Path to the image or base64 encoded image.
+		/// Supported formats are PNG, JPG, BMP.
+		/// 
+		/// To encode 
+		/// </summary>
+		public string Image { get; }
+
+		/// <summary>
+		/// Text displayed on the button in Checkbot.
+		/// </summary>
+		public string Text { get; }
+
+		/// <summary>
+		/// Tooltip of the button in Checkbot.
+		/// </summary>
+		public string Tooltip { get; }
+
+		/// <summary>
+		/// List of typologies, which are allowed to be used for export/open.
+		/// </summary>
+		public IEnumerable<string> AllowedTypology { get; }
+
+		public OpenButtonDescriptor(string name, string image, string text, string tooltip, IEnumerable<string> allowedTypology)
+		{
+			Name = name;
+			Image = image;
+			Text = text;
+			Tooltip = tooltip;
+			AllowedTypology = allowedTypology;
+		}
+	}
+}

--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Descriptors/SystemActionsDescriptor.cs
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Descriptors/SystemActionsDescriptor.cs
@@ -1,10 +1,10 @@
 ﻿namespace IdeaStatiCa.CheckbotPlugin.PluginList.Descriptors
 {
 	public sealed class SystemActionsDescriptor
-	{
-		public ActionButtonDescriptor? Open { get; }
+	{		
+		public OpenButtonDescriptor? Open { get; }
 
-		public SystemActionsDescriptor(ActionButtonDescriptor? open)
+		public SystemActionsDescriptor(OpenButtonDescriptor? open)
 		{
 			Open = open;
 		}

--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Json/OpenButton.cs
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Json/OpenButton.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace IdeaStatiCa.CheckbotPlugin.PluginList.Json
+{
+	internal class OpenButton
+	{
+		[JsonPropertyName("name")]
+		public string Name { get; set; } = string.Empty;
+
+		[JsonPropertyName("image")]
+		public string Image { get; set; } = string.Empty;
+
+		[JsonPropertyName("text")]
+		public string Text { get; set; } = string.Empty;
+
+		[JsonPropertyName("tooltip")]
+		public string Tooltip { get; set; } = string.Empty;
+
+		[JsonPropertyName("typology")]
+		public IEnumerable<string> AllowedTypologyCodes { get; set; } = new List<string> { "X+" };
+	}
+}

--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Json/SystemActions.cs
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Json/SystemActions.cs
@@ -5,6 +5,6 @@ namespace IdeaStatiCa.CheckbotPlugin.PluginList.Json
 	internal class SystemActions
 	{
 		[JsonPropertyName("open")]
-		public ActionButton? Open { get; set; }
+		public OpenButton? Open { get; set; }
 	}
 }

--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Mappers/Mapper.OpenButton.cs
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Mappers/Mapper.OpenButton.cs
@@ -1,0 +1,32 @@
+﻿namespace IdeaStatiCa.CheckbotPlugin.PluginList.Mappers
+{
+	internal static partial class Mapper
+	{
+		internal static Descriptors.OpenButtonDescriptor? Map(Json.OpenButton? source)
+		{
+			if (source is null)
+			{
+				return null;
+			}
+
+			return new Descriptors.OpenButtonDescriptor(source.Name, source.Image, source.Text, source.Tooltip, source.AllowedTypologyCodes);
+		}
+
+		internal static Json.OpenButton? Map(Descriptors.OpenButtonDescriptor? source)
+		{
+			if (source is null)
+			{
+				return null;
+			}
+
+			return new Json.OpenButton
+			{
+				Name = source.Name,
+				Image = source.Image,
+				Text = source.Text,
+				Tooltip = source.Tooltip,
+				AllowedTypologyCodes = source.AllowedTypology,
+			};
+		}
+	}
+}

--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.Protos/application_service.proto
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.Protos/application_service.proto
@@ -5,8 +5,9 @@ option csharp_namespace = "IdeaStatiCa.CheckbotPlugin.Protos";
 package ideastatica.checkbotplugin.v1;
 
 service ApplicationService {
-	rpc GetSettings(GetSettingsReq) returns (GetSettingsResp);
-	rpc GetAllSettings(GetAllSettingsReq) returns (GetAllSettingsResp);
+    rpc GetSettings(GetSettingsReq) returns (GetSettingsResp);
+    rpc GetAllSettings(GetAllSettingsReq) returns (GetAllSettingsResp);
+    rpc SetAllowedTypology(SetAllowedTypologyReq) returns (SetAllowedTypologyResp);
 }
 
 message GetSettingsReq {
@@ -25,6 +26,12 @@ message GetAllSettingsResp {
 }
 
 message SettingsValue {
-	string name = 1;
-	string value = 2;
+    string name = 1;
+    string value = 2;
 }
+
+message SetAllowedTypologyReq {
+    repeated string values = 1;
+}
+
+message SetAllowedTypologyResp { }

--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin/Services/IApplicationService.cs
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin/Services/IApplicationService.cs
@@ -22,5 +22,12 @@ namespace IdeaStatiCa.CheckbotPlugin.Services
 		/// </summary>
 		/// <returns>Collection of all application settings</returns>
 		Task<IReadOnlyCollection<SettingsValue>> GetAllSettings();
+
+		/// <summary>
+		/// Sets which typology of connections are allowed to be exported
+		/// </summary>
+		/// <param name="typologyCodes"></param>
+		/// <returns></returns>
+		Task SetAllowedTypology (IEnumerable<string> typologyCodes);
 	}
 }


### PR DESCRIPTION
New implementation:
- Separate OpenButton 
-- previously used ActionButton, now new OpenButton, which has new configuration feature 
-- it can be set, for which topologies of selected connection the button will be enabled
-- this can be set via config .json file, where the settings for plugin are located via property "topology"
-- e.g.: 
```
"actions": {
            "open": {
                "image": "path_to_file",
                "text": "Open",
                "tooltip": "Opens Plugin",
		"typology": ["X+", "X+Y+"]
                        }
           }
```
- Creation of new service for setting of allowed typologies to be opened (exported)
-- new method in IApplicationService allow you to set, which connection typologies will be possible to open in plugin (Open button will be enabled for those)
-- can be multiple values (collection of strings)