### PR TITLE
#19332 Typology default value fix

### DIFF
--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Json/OpenButton.cs
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList/Json/OpenButton.cs
@@ -18,6 +18,6 @@ namespace IdeaStatiCa.CheckbotPlugin.PluginList.Json
 		public string Tooltip { get; set; } = string.Empty;
 
 		[JsonPropertyName("typology")]
-		public IEnumerable<string> AllowedTypologyCodes { get; set; } = new List<string> { "X+" };
+		public IEnumerable<string> AllowedTypologyCodes { get; set; } = new List<string>();
 	}
 }


### PR DESCRIPTION
Fix of default behavior for new "typology" setting. When it is not defined, all the typologies are allowed.
