### PR TITLE
#24208 Prepare rstab link for net6

### DIFF
--- a/src/bim-links/rstab/IdeaRstabPlugin/CheckbotCommand.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/CheckbotCommand.cs
@@ -12,6 +12,7 @@ using System.Threading;
 namespace IdeaRstabPlugin
 {
 	[ComVisible(true)]
+	[Guid("E3FC6C61-64D2-479F-A103-0ADD30F89730")]
 	public class CheckbotCommand : IExternalCommand
 	{
 		private readonly static IPluginLogger _logger;

--- a/src/bim-links/rstab/IdeaRstabPlugin/IdeaRstabPlugin.csproj
+++ b/src/bim-links/rstab/IdeaRstabPlugin/IdeaRstabPlugin.csproj
@@ -2,10 +2,11 @@
   <Import Project="..\..\..\Common.props" />
   
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
     <Configurations>Debug;Release;Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal</Configurations>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>
+	<EnableComHosting>true</EnableComHosting>	
   </PropertyGroup>
   
   <ItemGroup>
@@ -25,8 +26,7 @@
     <ProjectReference Include="..\..\..\IdeaStatiCa.Plugin\IdeaStatiCa.Plugin.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="WindowsBase" />
+  <ItemGroup>    
 
     <Reference Include="Dlubal.RSTAB6">
       <HintPath>libs\Dlubal.RSTAB6.dll</HintPath>

--- a/src/bim-links/rstab/IdeaRstabPlugin/Properties/AssemblyInfo.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/Properties/AssemblyInfo.cs
@@ -4,5 +4,4 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyCulture("")]
 [assembly: Guid("74300C0C-9804-496C-9A9F-006C66DF1703")]
-[assembly: ComVisible(true)]
 [assembly: CLSCompliant(false)]


### PR DESCRIPTION
This is preparation of transition to net6 for Rstab plugin. Following changes were made:
- enable both net48 and net6 build of project
- remove usage of 'WindowsBase' net48 only library
- enable com hosting for dll and remove comvisible attribute on the general level
- use guid for CheckbotCommand