### PR TITLE
#25848 Use correct cache context for importing nodes

### DIFF
--- a/src/IdeaStatiCa.BimApiLink/CadBimLink.cs
+++ b/src/IdeaStatiCa.BimApiLink/CadBimLink.cs
@@ -39,7 +39,7 @@ namespace IdeaStatiCa.BimApiLink
 			Project project = new Project(logger, jsonPersistence);
 			ProjectAdapter projectAdapter = new ProjectAdapter(project, bimApiImporter);
 
-			CadModelAdapter cadModelAdapter = new CadModelAdapter(bimApiImporter, model as ICadModel, remoteApp, ApplicationName, _itemsComparer);
+			CadModelAdapter cadModelAdapter = new CadModelAdapter(model as ICadModel, remoteApp, ApplicationName, _itemsComparer);
 
 			IBimImporter bimImporter = BimImporter.BimImporter.Create(
 				cadModelAdapter,

--- a/src/IdeaStatiCa.BimApiLink/FeaBimLink.cs
+++ b/src/IdeaStatiCa.BimApiLink/FeaBimLink.cs
@@ -37,7 +37,7 @@ namespace IdeaStatiCa.BimApiLink
 			JsonProjectStorage projectStorage = new JsonProjectStorage(jsonPersistence, projectPath);
 			Project project = new Project(logger, jsonPersistence);
 			ProjectAdapter projectAdapter = new ProjectAdapter(project, bimApiImporter);
-			FeaModelAdapter feaModelAdapter = new FeaModelAdapter(bimApiImporter, model as IFeaModel);
+			FeaModelAdapter feaModelAdapter = new FeaModelAdapter(model as IFeaModel);
 
 			IBimImporter bimImporter = BimImporter.BimImporter.Create(
 				feaModelAdapter,

--- a/src/IdeaStatiCa.BimApiLink/Plugin/CadModel.cs
+++ b/src/IdeaStatiCa.BimApiLink/Plugin/CadModel.cs
@@ -1,26 +1,23 @@
 ﻿using IdeaRS.OpenModel;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimApiLink.Identifiers;
-using IdeaStatiCa.BimApiLink.Importers;
 using IdeaStatiCa.Plugin;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace IdeaStatiCa.BimApiLink.Plugin
 {
-	internal class CadModelAdapter : IIdeaModel
+	internal class CadModelAdapter : BimLinkObject, IIdeaModel
 	{
 		private CadUserSelection _lastSelection;
 
-		private readonly IBimApiImporter _bimApiImporter;
 		private readonly ICadModel _cadModel;
 		private readonly IProgressMessaging _remoteApp;
 		private readonly string _applicationName;
 		private IComparer<IIdentifier> _itemsComparer;
 
-		public CadModelAdapter(IBimApiImporter bimApiImporter, ICadModel cadModel, IProgressMessaging remoteApp, string applicationName, IComparer<IIdentifier> itemsComparer)
-		{
-			_bimApiImporter = bimApiImporter;
+		public CadModelAdapter(ICadModel cadModel, IProgressMessaging remoteApp, string applicationName, IComparer<IIdentifier> itemsComparer)
+		{			
 			_cadModel = cadModel;
 			_remoteApp = remoteApp;
 			_applicationName = applicationName;
@@ -35,7 +32,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 		public ISet<IIdeaMember1D> GetMembers()
 		{
 			return _cadModel.GetAllMembers()
-				.Select(x => _bimApiImporter.Get(x))
+				.Select(x => Get(x))
 				.Where(x => x != null)
 				.ToHashSet();
 		}
@@ -70,13 +67,13 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 			foreach (var selection in selections)
 			{
 				_lastSelection = selection;
-				var connectionPoint = _bimApiImporter.Get(selection.ConnectionPoint);
+				var connectionPoint = Get(selection.ConnectionPoint);
 
 				nodes.Add(connectionPoint.Node);
 
 
 				var connectedMembers = selection.Members
-				.Select(x => _bimApiImporter.Get(x))
+				.Select(x => Get(x))
 				.Where(x => x != null)
 				.ToHashSet();
 
@@ -108,12 +105,12 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 				return new SingleSelection(nodes, new HashSet<IIdeaMember1D>());
 			}
 
-			var connectionPoint = _bimApiImporter.Get(selection.ConnectionPoint);
+			var connectionPoint = Get(selection.ConnectionPoint);
 
 			nodes.Add(connectionPoint.Node);
 
 			var connectedMembers = selection.Members
-				.Select(x => _bimApiImporter.Get(x))
+				.Select(x => Get(x))
 				.Where(x => x != null)
 				.ToHashSet();
 
@@ -158,7 +155,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 				{
 					case nameof(IIdeaPlate):
 						{
-							var plate = _bimApiImporter.Get(item) as IIdeaPlate;
+							var plate = BimApiImporter.Get(item) as IIdeaPlate;
 							if (plate != null)
 							{
 								(connectionPoint.Plates as List<IIdeaPlate>).Add(plate);
@@ -167,7 +164,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 						}
 					case nameof(IIdeaFoldedPlate):
 						{
-							var foldedPlate = _bimApiImporter.Get(item) as IIdeaFoldedPlate;
+							var foldedPlate = BimApiImporter.Get(item) as IIdeaFoldedPlate;
 							if (foldedPlate != null)
 							{
 								(connectionPoint.FoldedPlates as List<IIdeaFoldedPlate>).Add(foldedPlate);
@@ -176,7 +173,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 						}
 					case nameof(IIdeaCut):
 						{
-							var cut = _bimApiImporter.Get(item) as IIdeaCut;
+							var cut = BimApiImporter.Get(item) as IIdeaCut;
 							if (cut != null)
 							{
 								(connectionPoint.Cuts as List<IIdeaCut>).Add(cut);
@@ -186,7 +183,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 
 					case nameof(IIdeaWeld):
 						{
-							var weld = _bimApiImporter.Get(item) as IIdeaWeld;
+							var weld = BimApiImporter.Get(item) as IIdeaWeld;
 							if (weld != null)
 							{
 								(connectionPoint.Welds as List<IIdeaWeld>).Add(weld);
@@ -195,7 +192,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 						}
 					case nameof(IIdeaBoltGrid):
 						{
-							var boltGrid = _bimApiImporter.Get(item) as IIdeaBoltGrid;
+							var boltGrid = BimApiImporter.Get(item) as IIdeaBoltGrid;
 							if (boltGrid != null)
 							{
 								(connectionPoint.BoltGrids as List<IIdeaBoltGrid>).Add(boltGrid);
@@ -204,7 +201,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 						}
 					case nameof(IIdeaAnchorGrid):
 						{
-							var anchorGrid = _bimApiImporter.Get(item) as IIdeaAnchorGrid;
+							var anchorGrid = BimApiImporter.Get(item) as IIdeaAnchorGrid;
 							if (anchorGrid != null)
 							{
 								(connectionPoint.AnchorGrids as List<IIdeaAnchorGrid>).Add(anchorGrid);
@@ -213,7 +210,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 						}
 					case nameof(IIdeaConnectedMember):
 						{
-							var stiffeningMember = _bimApiImporter.Get(item) as IIdeaConnectedMember;
+							var stiffeningMember = BimApiImporter.Get(item) as IIdeaConnectedMember;
 							if (stiffeningMember != null)
 							{
 								stiffeningMember.ConnectedMemberType = IdeaConnectedMemberType.Stiffening;

--- a/src/IdeaStatiCa.BimApiLink/Plugin/FeaModel.cs
+++ b/src/IdeaStatiCa.BimApiLink/Plugin/FeaModel.cs
@@ -1,5 +1,4 @@
 ﻿using IdeaRS.OpenModel;
-using IdeaStatiCa.BimApiLink.Importers;
 using IdeaStatiCa.BimApi;
 using System;
 using System.Collections.Generic;
@@ -7,14 +6,12 @@ using System.Linq;
 
 namespace IdeaStatiCa.BimApiLink.Plugin
 {
-	internal class FeaModelAdapter : IIdeaModel
+	internal class FeaModelAdapter : BimLinkObject, IIdeaModel
 	{
-		private readonly IBimApiImporter _bimApiImporter;
 		private readonly IFeaModel _feaModel;
 
-		public FeaModelAdapter(IBimApiImporter bimApiImporter, IFeaModel feaModel)
+		public FeaModelAdapter(IFeaModel feaModel)
 		{
-			_bimApiImporter = bimApiImporter;
 			_feaModel = feaModel;
 		}
 
@@ -22,7 +19,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 		{
 
 			return _feaModel.GetAllCombinations()
-				.Select(x => _bimApiImporter.Get(x))
+				.Select(x => Get(x))
 				.Cast<IIdeaLoading>()
 				.ToHashSet();
 		}
@@ -30,7 +27,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 		public ISet<IIdeaMember1D> GetMembers()
 		{
 			return _feaModel.GetAllMembers()
-				.Select(x => _bimApiImporter.Get(x))
+				.Select(x => Get(x))
 				.Where(x => x != null)
 				.ToHashSet();
 		}
@@ -43,17 +40,17 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 			FeaUserSelection selection = _feaModel.GetUserSelection();
 
 			var nodes = selection.Nodes
-				.Select(x => _bimApiImporter.Get(x))
+				.Select(x => Get(x))
 				.Where(x => x != null)
 				.ToHashSet();
 
 			var members = selection.Members
-				.Select(x => _bimApiImporter.Get(x))
+				.Select(x => Get(x))
 				.Where(x => x != null)
 				.ToHashSet();
 
 			var members2D = selection.Members2D
-				.Select(x => _bimApiImporter.Get(x))
+				.Select(x => Get(x))
 				.Where(x => x != null)
 				.ToHashSet();
 


### PR DESCRIPTION
During import via BimApiLink, all the nodes were created twice due to wrong cache used for the first import based on the selection. It effects all the links using BimApiLink structure. 

The fix is on the Fea/CadModel level, where now the correct importer and its correct cache is used. 
