### PR TITLE
#25848 BimApiLink - fix for null return in Get methods

### DIFF
--- a/src/IdeaStatiCa.BimApiLink/Plugin/CadModel.cs
+++ b/src/IdeaStatiCa.BimApiLink/Plugin/CadModel.cs
@@ -32,7 +32,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 		public ISet<IIdeaMember1D> GetMembers()
 		{
 			return _cadModel.GetAllMembers()
-				.Select(x => Get(x))
+				.Select(x => GetMaybe(x))
 				.Where(x => x != null)
 				.ToHashSet();
 		}
@@ -67,13 +67,13 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 			foreach (var selection in selections)
 			{
 				_lastSelection = selection;
-				var connectionPoint = Get(selection.ConnectionPoint);
+				var connectionPoint = GetMaybe(selection.ConnectionPoint);
 
 				nodes.Add(connectionPoint.Node);
 
 
 				var connectedMembers = selection.Members
-				.Select(x => Get(x))
+				.Select(x => GetMaybe(x))
 				.Where(x => x != null)
 				.ToHashSet();
 
@@ -105,12 +105,12 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 				return new SingleSelection(nodes, new HashSet<IIdeaMember1D>());
 			}
 
-			var connectionPoint = Get(selection.ConnectionPoint);
+			var connectionPoint = GetMaybe(selection.ConnectionPoint);
 
 			nodes.Add(connectionPoint.Node);
 
 			var connectedMembers = selection.Members
-				.Select(x => Get(x))
+				.Select(x => GetMaybe(x))
 				.Where(x => x != null)
 				.ToHashSet();
 

--- a/src/IdeaStatiCa.BimApiLink/Plugin/FeaModel.cs
+++ b/src/IdeaStatiCa.BimApiLink/Plugin/FeaModel.cs
@@ -19,7 +19,8 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 		{
 
 			return _feaModel.GetAllCombinations()
-				.Select(x => Get(x))
+				.Select(x => GetMaybe(x))
+				.Where(x => x != null)
 				.Cast<IIdeaLoading>()
 				.ToHashSet();
 		}
@@ -27,7 +28,7 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 		public ISet<IIdeaMember1D> GetMembers()
 		{
 			return _feaModel.GetAllMembers()
-				.Select(x => Get(x))
+				.Select(x => GetMaybe(x))
 				.Where(x => x != null)
 				.ToHashSet();
 		}
@@ -40,17 +41,17 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 			FeaUserSelection selection = _feaModel.GetUserSelection();
 
 			var nodes = selection.Nodes
-				.Select(x => Get(x))
+				.Select(x => GetMaybe(x))
 				.Where(x => x != null)
 				.ToHashSet();
 
 			var members = selection.Members
-				.Select(x => Get(x))
+				.Select(x => GetMaybe(x))
 				.Where(x => x != null)
 				.ToHashSet();
 
 			var members2D = selection.Members2D
-				.Select(x => Get(x))
+				.Select(x => GetMaybe(x))
 				.Where(x => x != null)
 				.ToHashSet();
 


### PR DESCRIPTION
In PR #809 there were made changes for using the correct BimApiImporter during the import - to correctly use the cache. But in this new flow, there need to be handled case, where the importer itself is returning null and object can not be created. Fixed by calling 'GetMaybe' instead of just 'Get', which leads to the same logic as with previous importer.
