### PR TITLE
Adding Eps0 to MatConcreteACI

### DIFF
--- a/src/IdeaRS.OpenModel/Libraries/Material/MatConcreteACI.cs
+++ b/src/IdeaRS.OpenModel/Libraries/Material/MatConcreteACI.cs
@@ -24,5 +24,9 @@ namespace IdeaRS.OpenModel.Material
 		/// </summary>
 		public double Fcc { get; set; }
 
+		/// <summary>
+		/// ε_0
+		/// </summary>
+		public double Eps0 { get; set; }
 	}
 }


### PR DESCRIPTION
Hopefully, it's OK to merge this into main branch, despite the change being needed for develop_25.0.0 (both develop and develop_25.0.0 point to the latest commit of public repo's main branch)