### PR TITLE
#27082 Ignore basic types during serialization

### DIFF
--- a/src/IdeaStatiCa.BimImporter/Persistence/JsonPersistence.cs
+++ b/src/IdeaStatiCa.BimImporter/Persistence/JsonPersistence.cs
@@ -24,7 +24,7 @@ namespace IdeaStatiCa.BimImporter.Persistence
 			{
 				Formatting = Formatting.Indented,
 				Converters = new List<JsonConverter>() { _tokenConverter },
-				TypeNameHandling = TypeNameHandling.Auto,
+				TypeNameHandling = TypeNameHandling.None,
 			};
 		}
 


### PR DESCRIPTION
There have been issues with deserialization of jsons from the older versions of IDEA app, which used to be using 'TypeNameHandling.All' option, on .NET6. 
We have tried to fix those issue by setting it to 'Auto' (in PR #780), but it was not working correctly. 

The 'Auto' option seems to be working correctly for links in net4.8 framework, but still fails on NET6+. Based on the documentation recommended option is 'None'. Which ignores basic types.
https://www.newtonsoft.com/json/help/html/P_Newtonsoft_Json_JsonSerializerSettings_TypeNameHandling.htm

We are using also some our specific types (Tokens), but those are serialized/deserialized still with the 'All' option, which works still correctly on both frameworks for those cases, because we fully specify the types there.

