### PR TITLE
#27082 Issu with mixing old and new content in bimapi json

### DIFF
--- a/src/IdeaStatiCa.BimApiLink/Persistence/ProjectStorage.cs
+++ b/src/IdeaStatiCa.BimApiLink/Persistence/ProjectStorage.cs
@@ -18,7 +18,7 @@ namespace IdeaStatiCa.BimApiLink.Persistence
 
 		public void Save()
 		{
-			using (FileStream fs = File.OpenWrite(_path))
+			using (FileStream fs = File.Create(_path))
 			using (StreamWriter streamWriter = new StreamWriter(fs))
 			{
 				_filePersistence.Save(streamWriter);


### PR DESCRIPTION
Due to changes in #780, when user updates project and rewrite bimapi-data.json file during first import, the new content was always shorter (because the types are no longer explicitly defined there) and it resulted in corrupted JSON. 

The cause was usage of File.OpenWrite() method, which always rewrites existing file. We need to clear original content of it first, so it was replaced by File.Create() method, which basically throws away already existing file, if there is any.