### PR TITLE
#23312 Removed silent catching of exceptions in hooks

### DIFF
--- a/src/IdeaStatiCa.BimApiLink/Hooks/AbstractHookManager.cs
+++ b/src/IdeaStatiCa.BimApiLink/Hooks/AbstractHookManager.cs
@@ -16,14 +16,7 @@ namespace IdeaStatiCa.BimApiLink.Hooks
 		{
 			foreach (T hook in _hooks)
 			{
-				try
-				{
-					func(hook);
-				}
-				catch
-				{
-					// TODO: log exception
-				}
+				func(hook);				
 			}
 		}
 	}


### PR DESCRIPTION
Hooks were silently catching the exceptions. Catching was removed, so if there is any exception thrown, it is properly propagated through call stack. 
