### PR TITLE
#29517 RSTAB - eccentricity

### DIFF
--- a/src/bim-links/rstab/IdeaRstabPlugin/BimApi/RstabElement1D.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/BimApi/RstabElement1D.cs
@@ -1,5 +1,4 @@
 ﻿using IdeaRS.OpenModel.Geometry3D;
-using IdeaRS.OpenModel.Model;
 using IdeaRstabPlugin.Factories;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimApi.Results;
@@ -30,15 +29,7 @@ namespace IdeaRstabPlugin.BimApi
 					return _objectFactory.GetCrossSection(_endCssNo);
 				}
 			}
-		}
-
-		public IdeaVector3D EccentricityBegin { get; set; } = new IdeaVector3D(0.0, 0.0, 0.0);
-
-		public IdeaVector3D EccentricityEnd { get; set; } = new IdeaVector3D(0.0, 0.0, 0.0);
-
-		public InsertionPoints CardinalPoint { get; set; }
-
-		public EccentricityReference EccentricityReference { get; set; }
+		}		
 
 		public double RotationRx { get; }
 

--- a/src/bim-links/rstab/IdeaRstabPlugin/BimApi/RstabMember.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/BimApi/RstabMember.cs
@@ -38,8 +38,8 @@ namespace IdeaRstabPlugin.BimApi
 
 		public bool MirrorZ => false;
 
-		public IdeaVector3D EccentricityBegin { get; } = new IdeaVector3D(0, 0, 0);
-		public IdeaVector3D EccentricityEnd { get; } = new IdeaVector3D(0, 0, 0);
+		public IdeaVector3D EccentricityBegin { get; }
+		public IdeaVector3D EccentricityEnd { get; }
 		public InsertionPoints InsertionPoint { get; }
 		public EccentricityReference EccentricityReference { get; }
 
@@ -53,13 +53,20 @@ namespace IdeaRstabPlugin.BimApi
 			IModelDataProvider modelDataProvider,
 			IResultsFactory resultsFactory,
 			IElementFactory elementFactory,
-			int memberNo)
+			int memberNo,
+			IdeaVector3D begin, IdeaVector3D end,
+			InsertionPoints insertionPoint, EccentricityReference eccRef)
 		{
 			_objectFactory = objectFactory;
 			_modelDataProvider = modelDataProvider;
 			_resultsFactory = resultsFactory;
 			_elementFactory = elementFactory;
 			_memberNo = memberNo;
+
+			EccentricityBegin = begin;
+			EccentricityEnd = end;
+			EccentricityReference = eccRef;
+			InsertionPoint = insertionPoint;
 
 			_logger.LogDebug($"Created {nameof(RstabMember)} with id {Id}");
 		}

--- a/src/bim-links/rstab/IdeaRstabPlugin/Factories/ElementFactory.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/Factories/ElementFactory.cs
@@ -48,11 +48,7 @@ namespace IdeaRstabPlugin.Factories
 				memberData.EndNodeNo,
 				memberData.StartCrossSectionNo,
 				memberData.EndCrossSectionNo,
-				rotationRad)
-			{
-				EccentricityBegin = GetEccentricity(member, 0.0, (CoordSystemByVector)lcs),
-				EccentricityEnd = GetEccentricity(member, 1.0, (CoordSystemByVector)lcs)
-			};
+				rotationRad);
 
 			return new List<IIdeaElement1D>() { element };
 		}

--- a/src/bim-links/rstab/IdeaRstabPlugin/Factories/ElementFactory.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/Factories/ElementFactory.cs
@@ -175,28 +175,6 @@ namespace IdeaRstabPlugin.Factories
 		private NMVector3D Vector2MNVector(IdeaVector3D vector3D)
 		{
 			return new NMVector3D(vector3D.X, vector3D.Y, vector3D.Z);
-		}
-
-		private IdeaVector3D GetEccentricity(IMember member, double param, CoordSystemByVector cs)
-		{
-			Dlubal.RSTAB8.Point3D point = member.GetEccentricity(param, false);
-			
-			if (_importSession.IsGCSOrientedUpwards)
-			{
-				return TransformToLCS(new IdeaVector3D(point.X, point.Y, point.Z), cs);
-			}
-			else
-			{
-				return TransformToLCS(new IdeaVector3D(point.X, -point.Y, -point.Z), cs);
-			}
-		}
-
-		private static IdeaVector3D TransformToLCS(IdeaVector3D vec, CoordSystemByVector cs)
-		{			
-			double x = (vec.X * cs.VecX.X) + (vec.Y * cs.VecX.Y) + (vec.Z * cs.VecX.Z);
-			double y = (vec.X * cs.VecY.X) + (vec.Y * cs.VecY.Y) + (vec.Z * cs.VecY.Z);
-			double z = (vec.X * cs.VecZ.X) + (vec.Y * cs.VecZ.Y) + (vec.Z * cs.VecZ.Z);			
-			return new IdeaVector3D(x, y, z);
-		}
+		}		
 	}
 }

--- a/src/bim-links/rstab/IdeaRstabPlugin/Factories/MemberFactory.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/Factories/MemberFactory.cs
@@ -1,9 +1,11 @@
 ﻿using Dlubal.RSTAB8;
+using IdeaRS.OpenModel.Model;
 using IdeaRstabPlugin.BimApi;
 using IdeaRstabPlugin.Providers;
 using IdeaStatiCa.BimApi;
 using IdeaStatiCa.Plugin;
 using IdeaStatiCa.PluginLogger;
+using System.Collections.Generic;
 
 namespace IdeaRstabPlugin.Factories
 {
@@ -37,11 +39,16 @@ namespace IdeaRstabPlugin.Factories
 			}
 
 			_resultsProvider.Prefetch(member.No);
+
+			var eccNo = member.EccentricityNo;
+			(IdeaVector3D begin, IdeaVector3D end, InsertionPoints insertionPoint, EccentricityReference eccRef) ecc = GetEccentricity(eccNo, importSession);
+
 			return new RstabMember(objectFactory,
 						  _modelDataProvider,
 						  _resultsFactory,
 						  _elementFactory,
-						  memberNo);
+						  memberNo,
+						  ecc.begin, ecc.end, ecc.insertionPoint, ecc.eccRef);
 		}
 
 		private static bool CanImport(Member member)
@@ -72,5 +79,90 @@ namespace IdeaRstabPlugin.Factories
 
 			return true;
 		}
+
+		private (IdeaVector3D, IdeaVector3D, InsertionPoints, EccentricityReference) GetEccentricity(int eccNo, IImportSession importSession)
+		{
+			// member without any ecc 
+			if (eccNo <= 0)
+			{
+				return DefaultEcc();
+			}
+
+			Dlubal.RSTAB8.MemberEccentricity dlubalEcc = _modelDataProvider.GetMemberEccentricity(eccNo);
+
+			// ecc set realtively to another object - unsupported case
+			if (dlubalEcc.TransverseOffset)
+			{
+				return DefaultEcc();
+			}
+
+			// insertion point
+			var insertionPoint = GetInsertionPoint(dlubalEcc);
+
+			// coord system
+			var (valid, eccRef) = GetEccCoordSystem(dlubalEcc.ReferenceSystem);
+			if (!valid)
+			{
+				return DefaultEcc();
+			}
+
+			var eccVectors = GetAbsoluteEcc(dlubalEcc, eccRef, importSession);
+
+			return (eccVectors.begin, eccVectors.end, insertionPoint, eccRef);
+		}
+
+		private (IdeaVector3D begin, IdeaVector3D end) GetAbsoluteEcc(MemberEccentricity ecc, EccentricityReference eccRef, IImportSession importSession)
+		{
+			if (eccRef == EccentricityReference.GlobalCoordinateSystem && importSession.IsGCSOrientedUpwards == false)
+			{
+				return (new IdeaVector3D(ecc.Start.X, -ecc.Start.Y, -ecc.Start.Z), new IdeaVector3D(ecc.End.X, -ecc.End.Y, -ecc.End.Z));
+			}
+			else
+			{
+				return (new IdeaVector3D(ecc.Start.X, ecc.Start.Y, ecc.Start.Z), new IdeaVector3D(ecc.End.X, ecc.End.Y, ecc.End.Z));
+			}
+		}
+
+		private static (bool valid, EccentricityReference coordSys) GetEccCoordSystem(ReferenceSystemType eccRef)
+		{
+			switch (eccRef)
+			{
+				case ReferenceSystemType.GlobalSystemType:
+					return (true, EccentricityReference.GlobalCoordinateSystem);
+				case ReferenceSystemType.LocalSystemType:
+					return (true, EccentricityReference.LocalCoordinateSystem);
+				default:
+					return (false, EccentricityReference.GlobalCoordinateSystem);
+			}
+		}		
+
+		private static InsertionPoints GetInsertionPoint(MemberEccentricity ecc)
+		{
+
+			if (_insertionPointMap.TryGetValue((ecc.HorizontalAlignment, ecc.VerticalAlignment), out var result))
+			{
+				return result;
+			}
+
+			// default
+			return InsertionPoints.CenterOfGravity;			
+		}
+
+		private static readonly Dictionary<(HorizontalAlignmentType, VerticalAlignmentType), InsertionPoints>
+			_insertionPointMap = new Dictionary<(HorizontalAlignmentType, VerticalAlignmentType), InsertionPoints>
+			{
+				{(HorizontalAlignmentType.Left, VerticalAlignmentType.Top), InsertionPoints.BottomLeft},
+				{(HorizontalAlignmentType.Left, VerticalAlignmentType.Middle), InsertionPoints.Left},
+				{(HorizontalAlignmentType.Left, VerticalAlignmentType.Bottom), InsertionPoints.TopLeft},
+				{(HorizontalAlignmentType.Center, VerticalAlignmentType.Top), InsertionPoints.Bottom},
+				{(HorizontalAlignmentType.Center, VerticalAlignmentType.Middle), InsertionPoints.CenterOfGravity},
+				{(HorizontalAlignmentType.Center, VerticalAlignmentType.Bottom), InsertionPoints.Top},
+				{(HorizontalAlignmentType.Right, VerticalAlignmentType.Top), InsertionPoints.BottomRight},
+				{(HorizontalAlignmentType.Right, VerticalAlignmentType.Middle), InsertionPoints.Right},
+				{(HorizontalAlignmentType.Right,  VerticalAlignmentType.Bottom), InsertionPoints.TopRight},
+			};
+
+		private static (IdeaVector3D, IdeaVector3D, InsertionPoints, EccentricityReference) DefaultEcc()
+			=> (new IdeaVector3D(0, 0, 0), new IdeaVector3D(0, 0, 0), InsertionPoints.CenterOfGravity, EccentricityReference.GlobalCoordinateSystem);
 	}
 }

--- a/src/bim-links/rstab/IdeaRstabPlugin/Providers/IModelDataProvider.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/Providers/IModelDataProvider.cs
@@ -13,6 +13,8 @@ namespace IdeaRstabPlugin.Providers
 
 		IEnumerable<Member> GetMembers();
 
+		MemberEccentricity GetMemberEccentricity(int no);
+
 		//Line GetLine(int no);
 	}
 }

--- a/src/bim-links/rstab/IdeaRstabPlugin/Providers/ModelDataProvider.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/Providers/ModelDataProvider.cs
@@ -77,5 +77,10 @@ namespace IdeaRstabPlugin.Providers
 		{
 			return GetOrCreate(no, DataType.Node, () => _modelData.GetNode(no, ItemAt.AtNo).GetData());
 		}
+
+		public MemberEccentricity GetMemberEccentricity(int no)
+		{
+			return _modelData.GetMemberEccentricity(no, ItemAt.AtNo).GetData();
+		}
 	}
 }


### PR DESCRIPTION
Based on the new possibilities related to handling of eccentricity inside BIMApi, the example of RSTAB link implementation was extended. 
Following changes made: 
- excentricity moved into member level
- enabled import of relative eccentricities (top, bottom, etc.)
- properly import global/local eccentricity values