### PR TITLE
#30063 - Biggest member uncertaininty resolution

### DIFF
--- a/src/IdeaStatiCa.BulkSelection/ItemsSorter.cs
+++ b/src/IdeaStatiCa.BulkSelection/ItemsSorter.cs
@@ -1154,7 +1154,7 @@ namespace IdeaStatiCa.BIM.Common
 
 		public static double Perimeter(this Rect rect)
 		{
-			return (rect.Width + rect.Height * 2);
+			return (rect.Width + rect.Height) * 2;
 		}
 	}
 }


### PR DESCRIPTION
 Uncertainity in GetBiggest member resolved via checking alignment with global X axis + if that's still uncertain, using size of CrossSectionBounds to decide which item is bigger
