### PR TITLE
30266 openning closing progress dialog marked obsolete for public

### DIFF
--- a/src/IdeaStatiCa.BimImporter/BimImporter.cs
+++ b/src/IdeaStatiCa.BimImporter/BimImporter.cs
@@ -274,7 +274,6 @@ namespace IdeaStatiCa.BimImporter
 				throw new ArgumentNullException(nameof(group));
 			}
 
-			_remoteApp?.InitProgressDialog();
 			_remoteApp?.SendMessageLocalised(MessageSeverity.Info, LocalisedMessage.ImportingGroups);
 
 			_logger.LogTrace($"Importing of bim items group, id '{group.Id}', type '{group.Type}', items count '{group.Items}'.");
@@ -360,7 +359,6 @@ namespace IdeaStatiCa.BimImporter
 			}
 			else
 			{
-				_remoteApp?.CancelMessage();
 				_logger.LogError($"BIMItemsGroup type '{group.Type}' is not supported.");
 				throw new NotImplementedException($"BIMItemsGroup type '{group.Type}' is not supported.");
 			}
@@ -368,7 +366,6 @@ namespace IdeaStatiCa.BimImporter
 
 		private BulkSelection InitBulkImport()
 		{
-			_remoteApp?.InitProgressDialog();
 			_remoteApp?.SendMessageLocalised(MessageSeverity.Info, LocalisedMessage.ModelImport);
 			BulkSelection selection = _ideaModel.GetBulkSelection();
 
@@ -379,7 +376,6 @@ namespace IdeaStatiCa.BimImporter
 
 		private BulkSelection InitImportOfWholeModel()
 		{
-			_remoteApp?.InitProgressDialog();
 			_remoteApp?.SendMessageLocalised(MessageSeverity.Info, LocalisedMessage.ModelImport);
 			BulkSelection selection = _ideaModel.GetWholeModel();
 			CheckNodesAndMembers(selection);
@@ -402,7 +398,6 @@ namespace IdeaStatiCa.BimImporter
 
 		private SingleSelection InitSingleImport()
 		{
-			_remoteApp?.InitProgressDialog();
 			_remoteApp?.SendMessageLocalised(MessageSeverity.Info, LocalisedMessage.ModelImport);
 			SingleSelection selection = _ideaModel.GetSingleSelection();
 

--- a/src/IdeaStatiCa.Plugin/IProgressMessaging.cs
+++ b/src/IdeaStatiCa.Plugin/IProgressMessaging.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 
 namespace IdeaStatiCa.Plugin
 {
@@ -43,7 +44,16 @@ namespace IdeaStatiCa.Plugin
 		void SendMessageLocalised(MessageSeverity severity, LocalisedMessage msg, string suffix = "");
 		void SendMessage(MessageSeverity severity, string text);
 		int SendMessageInteractive(MessageSeverity severity, string text, string[] buttons);
+
+		/// <summary>
+		/// Links shouldn't be able control showing/hiding progress dialog. This functionality should be handled by the host application.
+		/// </summary>
+		[Obsolete("CancelMessage method is obsolete. Links shouldn't be able control showing/hiding progress dialog. This functionality should be handled by the host application.")]
 		void CancelMessage();
+		/// <summary>
+		/// Links shouldn't be able control showing/hiding progress dialog. This functionality should be handled by the host application.
+		/// </summary>
+		[Obsolete("InitProgressDialog method is obsolete. Links shouldn't be able control showing/hiding progress dialog. This functionality should be handled by the host application.")]
 		void InitProgressDialog();
 
 		void SetStageLocalised(int stage, int stageMax, LocalisedMessage msg, params object[] args);

--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaApp/Services/RamFeaApplication.cs
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaApp/Services/RamFeaApplication.cs
@@ -80,7 +80,6 @@ namespace IdeaStatiCa.RamToIdeaApp.Services
 			{
 				_logger.LogDebug($"RamFeaApplication.ImportActiveAsync : countryCode = {countryCode}, requestedType = {requestedType}");
 
-				_progressMessaging?.InitProgressDialog();
 				_progressMessaging?.SendMessage(MessageSeverity.Info, "Waiting for BIM application");
 
 				if (requestedType == RequestedItemsType.Connections)


### PR DESCRIPTION
InitProgressDialog (openning) and CancelMessage (closing) progress dialog should be handled only by the host application, not by links. Those methods were marked obsolete