### PR TITLE
#30389 SAF example - fix missing results

### DIFF
--- a/examples/bimapi/CheckbotBimLink/SAF/SafFeaBimLink/SAFConverter.cs
+++ b/examples/bimapi/CheckbotBimLink/SAF/SafFeaBimLink/SAFConverter.cs
@@ -29,13 +29,13 @@ namespace SafFeaBimLink
 
 		public ModelBIM ImportConnections(SAFModel model, CountryCode countryCode)
 		{
-			IBimImporter importer = BimImporter.Create(model, _project, _pluginLogger);
+			IBimImporter importer = BimImporter.Create(model, _project, _pluginLogger, configuration: new SAFBimImporterConfiguration());
 			return importer.ImportConnections(countryCode);
 		}
 
 		public ModelBIM ImportMember(SAFModel model, CountryCode countryCode)
 		{
-			IBimImporter importer = BimImporter.Create(model, _project, _pluginLogger);
+			IBimImporter importer = BimImporter.Create(model, _project, _pluginLogger, configuration: new SAFBimImporterConfiguration());
 			return importer.ImportMembers(countryCode);
 		}
 


### PR DESCRIPTION
Fix for missing results in SAF based link example. 
The issue was caused by missing SAF import configuration, which provides the correct results processing.
