### PR TITLE
#31033: Downgrade of the Serilog nugets to 4.2.0/6.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,11 +54,11 @@
     <PackageVersion Include="ini-parser" Version="2.5.2" />
     <PackageVersion Include="morelinq" Version="4.4.0" />
     <PackageVersion Include="Polly" Version="8.6.2" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog" Version="4.2.0" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <!-- <PackageVersion Include="Tekla.Structures" Version="2024.0.0" />


### PR DESCRIPTION
* Downgrade of the Serilog version to the previous status:
  * Serilog 4.3.0 ->4.2.0
  * Serilog.Sinks.File 7.0.0 -> 6.0.0