### PR TITLE
#31167: IRcsController is now async disposable to allow a secure destruction

### DIFF
--- a/src/IdeaStatiCa.Api/RCS/IRcsController.cs
+++ b/src/IdeaStatiCa.Api/RCS/IRcsController.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace IdeaStatiCa.Api.RCS
 {
-	public interface IRcsController : IDisposable
+	public interface IRcsController : IAsyncDisposable
 	{
 		bool OpenIdeaProject(string ideaProjectPath);
 		bool OpenIdeaProjectFromIdeaOpenModel(string ideaOpenModelProjectPath, string projectName, string ideaOpenMessagesPath);


### PR DESCRIPTION
IRcsController changed from being derived from IDisposable to IAsyncDisposable