### PR TITLE
#31269: Removed obsolete Constants.ProjectDirectoryParam

### DIFF
--- a/src/IdeaStatiCa.PluginsTools/PluginTools/Tools/Constants.cs
+++ b/src/IdeaStatiCa.PluginsTools/PluginTools/Tools/Constants.cs
@@ -16,7 +16,6 @@ namespace IdeaRS
 		public static readonly string LibraryEntityDir = @"Library";
 		public static readonly string ProjectTempDirName = @"Temp";
 		public static readonly string SharedReposParam = @"-libReposPath:";
-		public static readonly string ProjectDirectoryParam = @"-projectDirPath:";
 		public static readonly string DesignCodeParam = @"-designCode:";
 		public static readonly string IdeaRsTempDirName = "IDEA_RS";
 		public static readonly string WsTempDirName = "TempWS";


### PR DESCRIPTION
Removed the Constants.ProjectDirectoryParam that is not handled in the apps.