### PR TITLE
26998 - Fix double writes for RAM

### DIFF
--- a/src/bim-links/bentley-ram/IdeaStatiCa.Ram25ToIdea/IdeaStatiCa.Ram25ToIdea.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.Ram25ToIdea/IdeaStatiCa.Ram25ToIdea.csproj
@@ -1,25 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Import Project="..\..\..\Common.props" />
-	<PropertyGroup>
-		<ProjectGuid>{881C74B0-CF8E-4911-9FB1-7DF91AF04036}</ProjectGuid>
-		<TargetFramework>net8.0-windows</TargetFramework>
-		<Configurations>Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal;Debug;Release</Configurations>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="Autofac" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-		<PackageReference Include="Idea.Bentley.Ram" />
-		<PackageReference Include="MathNet.Numerics" />
-		<PackageReference Include="MathNet.Spatial" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\..\..\IdeaRS.OpenModel\IdeaRS.OpenModel.csproj" />
-		<ProjectReference Include="..\..\..\IdeaStatiCa.BimApi\IdeaStatiCa.BimApi.csproj" />
-		<ProjectReference Include="..\..\..\IdeaStatiCa.BimImporter\IdeaStatiCa.BimImporter.csproj" />
-		<ProjectReference Include="..\..\..\IdeaStatiCa.Plugin\IdeaStatiCa.Plugin.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-	</ItemGroup>
-	<Import Project="..\IdeaStatiCa.BentleyCrossSections\IdeaStatiCa.BentleyCrossSections.projitems" Label="Shared" />
+  <Import Project="..\..\..\Common.props" />
+  <PropertyGroup>
+    <ProjectGuid>{881C74B0-CF8E-4911-9FB1-7DF91AF04036}</ProjectGuid>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Configurations>Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal;Debug;Release</Configurations>
+  </PropertyGroup>
+
+  <!-- Set OutputPath for *_Internal configurations -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release_IdeaStatiCa_Internal' Or '$(Configuration)' == 'Debug_IdeaStatiCa_Internal'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(OutputPath)\$(TargetFramework)\Ram25ToIdea_Internal\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Idea.Bentley.Ram" />
+    <PackageReference Include="MathNet.Numerics" />
+    <PackageReference Include="MathNet.Spatial" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\IdeaRS.OpenModel\IdeaRS.OpenModel.csproj" />
+    <ProjectReference Include="..\..\..\IdeaStatiCa.BimApi\IdeaStatiCa.BimApi.csproj" />
+    <ProjectReference Include="..\..\..\IdeaStatiCa.BimImporter\IdeaStatiCa.BimImporter.csproj" />
+    <ProjectReference Include="..\..\..\IdeaStatiCa.Plugin\IdeaStatiCa.Plugin.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="..\IdeaStatiCa.BentleyCrossSections\IdeaStatiCa.BentleyCrossSections.projitems" Label="Shared" />
 </Project>

--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdea/IdeaStatiCa.RamToIdea.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdea/IdeaStatiCa.RamToIdea.csproj
@@ -1,23 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Import Project="..\..\..\Common.props" />
-	<PropertyGroup>
-		<ProjectGuid>{ec8df878-7ce5-458d-bf3e-fec30768a104}</ProjectGuid>
-		<TargetFramework>net8.0-windows</TargetFramework>
-		<Configurations>Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal;Debug;Release</Configurations>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="Autofac" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-		<PackageReference Include="Idea.Bentley.Ram" VersionOverride="17.2.24"/>
-		<PackageReference Include="MathNet.Numerics" />
-		<PackageReference Include="MathNet.Spatial" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\..\..\IdeaRS.OpenModel\IdeaRS.OpenModel.csproj" />
-		<ProjectReference Include="..\..\..\IdeaStatiCa.BimApi\IdeaStatiCa.BimApi.csproj" />
-		<ProjectReference Include="..\..\..\IdeaStatiCa.BimImporter\IdeaStatiCa.BimImporter.csproj" />
-		<ProjectReference Include="..\..\..\IdeaStatiCa.Plugin\IdeaStatiCa.Plugin.csproj" />
-	</ItemGroup>
-	<Import Project="..\IdeaStatiCa.BentleyCrossSections\IdeaStatiCa.BentleyCrossSections.projitems" Label="Shared" />
+  <Import Project="..\..\..\Common.props" />
+  <PropertyGroup>
+    <ProjectGuid>{ec8df878-7ce5-458d-bf3e-fec30768a104}</ProjectGuid>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Configurations>Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal;Debug;Release</Configurations>
+  </PropertyGroup>
+  
+  <!-- Set OutputPath for *_Internal configurations -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release_IdeaStatiCa_Internal' Or '$(Configuration)' == 'Debug_IdeaStatiCa_Internal'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(OutputPath)\$(TargetFramework)\RamToIdea_Internal\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Idea.Bentley.Ram" VersionOverride="17.2.24"/>
+    <PackageReference Include="MathNet.Numerics" />
+    <PackageReference Include="MathNet.Spatial" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\IdeaRS.OpenModel\IdeaRS.OpenModel.csproj" />
+    <ProjectReference Include="..\..\..\IdeaStatiCa.BimApi\IdeaStatiCa.BimApi.csproj" />
+    <ProjectReference Include="..\..\..\IdeaStatiCa.BimImporter\IdeaStatiCa.BimImporter.csproj" />
+    <ProjectReference Include="..\..\..\IdeaStatiCa.Plugin\IdeaStatiCa.Plugin.csproj" />
+  </ItemGroup>
+  <Import Project="..\IdeaStatiCa.BentleyCrossSections\IdeaStatiCa.BentleyCrossSections.projitems" Label="Shared" />
 </Project>

--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaApp/IdeaStatiCa.RamToIdeaApp.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaApp/IdeaStatiCa.RamToIdeaApp.csproj
@@ -1,41 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Import Project="..\..\..\Common.props" />
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
-		<Configurations>Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal;Debug;Release</Configurations>
-		<UseWPF>true</UseWPF>
-		<ApplicationIcon>Resources\RAM icon.ico</ApplicationIcon>
-	</PropertyGroup>
+  <Import Project="..\..\..\Common.props" />
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Configurations>Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal;Debug;Release</Configurations>
+    <UseWPF>true</UseWPF>
+    <ApplicationIcon>Resources\RAM icon.ico</ApplicationIcon>
+  </PropertyGroup>
 
-	<!-- Set OutputPath for *_Internal configurations -->
-	<PropertyGroup Condition="'$(Configuration)' == 'Release_IdeaStatiCa_Internal' Or '$(Configuration)' == 'Debug_IdeaStatiCa_Internal'">
-		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<OutputPath>$(OutputPath)\$(TargetFramework)\RamToIdea_Internal\</OutputPath>
-	</PropertyGroup>
+  <!-- Set OutputPath for *_Internal configurations -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release_IdeaStatiCa_Internal' Or '$(Configuration)' == 'Debug_IdeaStatiCa_Internal'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>$(OutputPath)\$(TargetFramework)\RamToIdea_Internal\</OutputPath>
+  </PropertyGroup>
 
-	<ItemGroup>
-	  <None Remove="Resources\RAM icon.ico" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="Resources\RAM icon.ico" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-		<PackageReference Include="NSubstitute" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Idea.Bentley.Ram" VersionOverride="17.2.24"/>
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\..\Logger\IdeaStatiCa.PluginLogger\IdeaStatiCa.PluginLogger.csproj" />
-		<ProjectReference Include="..\IdeaStatiCa.RamToIdea\IdeaStatiCa.RamToIdea.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Logger\IdeaStatiCa.PluginLogger\IdeaStatiCa.PluginLogger.csproj" />
+    <ProjectReference Include="..\IdeaStatiCa.RamToIdea\IdeaStatiCa.RamToIdea.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <Resource Include="Resources\RAM icon.ico">
-	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-	  </Resource>
-	</ItemGroup>
+  <ItemGroup>
+    <Resource Include="Resources\RAM icon.ico">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Resource>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fix double writes for RAM by adding package reference with versionOverride
Set common output path for RamToIdea and RamToIdeaApp projects to avoid having two places with same dlls
