### PR TITLE
fix: reuse single RestClient in ApiClient to prevent TCP port exhaustion (#32846)

### DIFF
--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/Client/ApiClient.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/Client/ApiClient.cs
@@ -170,9 +170,11 @@ namespace IdeaStatiCa.ConnectionApi.Client
     /// Provides a default implementation of an Api client (both synchronous and asynchronous implementations),
     /// encapsulating general REST accessor use cases.
     /// </summary>
-    public partial class ApiClient : ISynchronousClient, IAsynchronousClient
+    public partial class ApiClient : ISynchronousClient, IAsynchronousClient, IDisposable
     {
         private readonly string _baseUrl;
+        private RestClient _restClient;
+        private readonly object _restClientLock = new object();
 
         /// <summary>
         /// Specifies the settings on a <see cref="JsonSerializer" /> object.
@@ -212,6 +214,42 @@ namespace IdeaStatiCa.ConnectionApi.Client
                 throw new ArgumentException("basePath cannot be empty");
 
             _baseUrl = basePath;
+        }
+
+        private RestClient GetOrCreateRestClient(string baseUrl, IReadableConfiguration configuration)
+        {
+            if (_restClient == null)
+            {
+                lock (_restClientLock)
+                {
+                    if (_restClient == null)
+                    {
+                        var clientOptions = new RestClientOptions(baseUrl)
+                        {
+                            ClientCertificates = configuration.ClientCertificates,
+                            MaxTimeout = configuration.Timeout,
+                            Proxy = configuration.Proxy,
+                            UserAgent = configuration.UserAgent,
+                            UseDefaultCredentials = configuration.UseDefaultCredentials,
+                            RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
+                        };
+
+                        _restClient = new RestClient(clientOptions,
+                            configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration)));
+                    }
+                }
+            }
+
+            return _restClient;
+        }
+
+        /// <summary>
+        /// Disposes the underlying RestClient and its HttpClient to release sockets.
+        /// </summary>
+        public void Dispose()
+        {
+            _restClient?.Dispose();
+            _restClient = null;
         }
 
         /// <summary>
@@ -456,100 +494,86 @@ namespace IdeaStatiCa.ConnectionApi.Client
         private ApiResponse<T> ExecClient<T>(Func<RestClient, RestResponse<T>> getResponse, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
+            var client = GetOrCreateRestClient(baseUrl, configuration);
 
-            var clientOptions = new RestClientOptions(baseUrl)
+            InterceptRequest(request);
+
+            RestResponse<T> response = getResponse(client);
+
+            if (response.ContentType == "text/plain" && typeof(T).Name == "Object")
             {
-                ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
-                Proxy = configuration.Proxy,
-                UserAgent = configuration.UserAgent,
-                UseDefaultCredentials = configuration.UseDefaultCredentials,
-                RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
-            };
-            setOptions(clientOptions);
-            
-            using (RestClient client = new RestClient(clientOptions,
-                configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
-            {
-                InterceptRequest(request);
-
-                RestResponse<T> response = getResponse(client);
-
-                if (response.ContentType == "text/plain" && typeof(T).Name == "Object")
-                {
-                  response.Data = (T)(object)response.Content.ToString();
-                  var res = ToApiResponse(response);
-                  return res;
-                }
-
-                if((response.ContentType == "application/octet-stream" || response.ContentType == "image/png") && typeof(T).Name == "Object")
-                {
-                    response.Data = (T)(object)response.RawBytes;
-                    var res = ToApiResponse(response);
-                    return res;
-                }
-
-                // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
-                if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
-                {
-                    try
-                    {
-                        response.Data = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
-                    }
-                    catch (Exception ex)
-                    {
-                        throw ex.InnerException != null ? ex.InnerException : ex;
-                    }
-                }
-                else if (typeof(T).Name == "Stream") // for binary response
-                {
-                    response.Data = (T)(object)new MemoryStream(response.RawBytes);
-                }
-                else if (typeof(T).Name == "Byte[]") // for byte response
-                {
-                    response.Data = (T)(object)response.RawBytes;
-                }
-                else if (typeof(T).Name == "String") // for string response
-                {
-                    response.Data = (T)(object)response.Content;
-                }
-
-                InterceptResponse(request, response);
-
-                var result = ToApiResponse(response);
-                if (response.ErrorMessage != null)
-                {
-                    result.ErrorText = response.ErrorMessage;
-                }
-
-                if (response.Cookies != null && response.Cookies.Count > 0)
-                {
-                    if (result.Cookies == null) result.Cookies = new List<Cookie>();
-                    foreach (var restResponseCookie in response.Cookies.Cast<Cookie>())
-                    {
-                        var cookie = new Cookie(
-                            restResponseCookie.Name,
-                            restResponseCookie.Value,
-                            restResponseCookie.Path,
-                            restResponseCookie.Domain
-                        )
-                        {
-                            Comment = restResponseCookie.Comment,
-                            CommentUri = restResponseCookie.CommentUri,
-                            Discard = restResponseCookie.Discard,
-                            Expired = restResponseCookie.Expired,
-                            Expires = restResponseCookie.Expires,
-                            HttpOnly = restResponseCookie.HttpOnly,
-                            Port = restResponseCookie.Port,
-                            Secure = restResponseCookie.Secure,
-                            Version = restResponseCookie.Version
-                        };
-
-                        result.Cookies.Add(cookie);
-                    }
-                }
-                return result;
+              response.Data = (T)(object)response.Content.ToString();
+              var res = ToApiResponse(response);
+              return res;
             }
+
+            if((response.ContentType == "application/octet-stream" || response.ContentType == "image/png") && typeof(T).Name == "Object")
+            {
+                response.Data = (T)(object)response.RawBytes;
+                var res = ToApiResponse(response);
+                return res;
+            }
+
+            // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+            if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            {
+                try
+                {
+                    response.Data = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                }
+                catch (Exception ex)
+                {
+                    throw ex.InnerException != null ? ex.InnerException : ex;
+                }
+            }
+            else if (typeof(T).Name == "Stream") // for binary response
+            {
+                response.Data = (T)(object)new MemoryStream(response.RawBytes);
+            }
+            else if (typeof(T).Name == "Byte[]") // for byte response
+            {
+                response.Data = (T)(object)response.RawBytes;
+            }
+            else if (typeof(T).Name == "String") // for string response
+            {
+                response.Data = (T)(object)response.Content;
+            }
+
+            InterceptResponse(request, response);
+
+            var result = ToApiResponse(response);
+            if (response.ErrorMessage != null)
+            {
+                result.ErrorText = response.ErrorMessage;
+            }
+
+            if (response.Cookies != null && response.Cookies.Count > 0)
+            {
+                if (result.Cookies == null) result.Cookies = new List<Cookie>();
+                foreach (var restResponseCookie in response.Cookies.Cast<Cookie>())
+                {
+                    var cookie = new Cookie(
+                        restResponseCookie.Name,
+                        restResponseCookie.Value,
+                        restResponseCookie.Path,
+                        restResponseCookie.Domain
+                    )
+                    {
+                        Comment = restResponseCookie.Comment,
+                        CommentUri = restResponseCookie.CommentUri,
+                        Discard = restResponseCookie.Discard,
+                        Expired = restResponseCookie.Expired,
+                        Expires = restResponseCookie.Expires,
+                        HttpOnly = restResponseCookie.HttpOnly,
+                        Port = restResponseCookie.Port,
+                        Secure = restResponseCookie.Secure,
+                        Version = restResponseCookie.Version
+                    };
+
+                    result.Cookies.Add(cookie);
+                }
+            }
+            return result;
         }
 
         /// <summary>
@@ -565,100 +589,86 @@ namespace IdeaStatiCa.ConnectionApi.Client
 		private async Task<ApiResponse<T>> ExecClientAsync<T>(Func<RestClient, Task<RestResponse<T>>> getResponseAsync, Action<RestClientOptions> setOptions, RestRequest request, RequestOptions options, IReadableConfiguration configuration)
 		{
 			var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
+			var client = GetOrCreateRestClient(baseUrl, configuration);
 
-			var clientOptions = new RestClientOptions(baseUrl)
+			InterceptRequest(request);
+
+			RestResponse<T> response = await getResponseAsync(client);
+
+			if (response.ContentType == "text/plain" && typeof(T).Name == "Object")
 			{
-				ClientCertificates = configuration.ClientCertificates,
-				MaxTimeout = configuration.Timeout,
-				Proxy = configuration.Proxy,
-				UserAgent = configuration.UserAgent,
-				UseDefaultCredentials = configuration.UseDefaultCredentials,
-				RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
-			};
-			setOptions(clientOptions);
-
-			using (RestClient client = new RestClient(clientOptions,
-				configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
-			{
-				InterceptRequest(request);
-
-				RestResponse<T> response = await getResponseAsync(client);
-
-				if (response.ContentType == "text/plain" && typeof(T).Name == "Object")
-				{
-					response.Data = (T)(object)response.Content.ToString();
-					var res = ToApiResponse(response);
-					return res;
-				}
-
-				if((response.ContentType == "application/octet-stream" || response.ContentType == "image/png") && typeof(T).Name == "Object")
-				{
-					response.Data = (T)(object)response.RawBytes;
-					var res = ToApiResponse(response);
-					return res;
-				}
-
-				// if the response type is oneOf/anyOf, call FromJSON to deserialize the data
-				if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
-				{
-					try
-					{
-						response.Data = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
-					}
-					catch (Exception ex)
-					{
-						throw ex.InnerException != null ? ex.InnerException : ex;
-					}
-				}
-				else if (typeof(T).Name == "Stream") // for binary response
-				{
-					response.Data = (T)(object)new MemoryStream(response.RawBytes);
-				}
-				else if (typeof(T).Name == "Byte[]") // for byte response
-				{
-					response.Data = (T)(object)response.RawBytes;
-				}
-				else if (typeof(T).Name == "String") // for string response
-				{
-					response.Data = (T)(object)response.Content;
-				}
-
-				InterceptResponse(request, response);
-
-				var result = ToApiResponse(response);
-				if (response.ErrorMessage != null)
-				{
-					result.ErrorText = response.ErrorMessage;
-				}
-
-				if (response.Cookies != null && response.Cookies.Count > 0)
-				{
-					if (result.Cookies == null) result.Cookies = new List<Cookie>();
-					foreach (var restResponseCookie in response.Cookies.Cast<Cookie>())
-					{
-						var cookie = new Cookie(
-							restResponseCookie.Name,
-							restResponseCookie.Value,
-							restResponseCookie.Path,
-							restResponseCookie.Domain
-						)
-						{
-							Comment = restResponseCookie.Comment,
-							CommentUri = restResponseCookie.CommentUri,
-							Discard = restResponseCookie.Discard,
-							Expired = restResponseCookie.Expired,
-							Expires = restResponseCookie.Expires,
-							HttpOnly = restResponseCookie.HttpOnly,
-							Port = restResponseCookie.Port,
-							Secure = restResponseCookie.Secure,
-							Version = restResponseCookie.Version
-						};
-
-						result.Cookies.Add(cookie);
-					}
-				}
-				return result;
+				response.Data = (T)(object)response.Content.ToString();
+				var res = ToApiResponse(response);
+				return res;
 			}
+
+			if((response.ContentType == "application/octet-stream" || response.ContentType == "image/png") && typeof(T).Name == "Object")
+			{
+				response.Data = (T)(object)response.RawBytes;
+				var res = ToApiResponse(response);
+				return res;
+			}
+
+			// if the response type is oneOf/anyOf, call FromJSON to deserialize the data
+			if (typeof(AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+			{
+				try
+				{
+					response.Data = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+				}
+				catch (Exception ex)
+				{
+					throw ex.InnerException != null ? ex.InnerException : ex;
+				}
+			}
+			else if (typeof(T).Name == "Stream") // for binary response
+			{
+				response.Data = (T)(object)new MemoryStream(response.RawBytes);
+			}
+			else if (typeof(T).Name == "Byte[]") // for byte response
+			{
+				response.Data = (T)(object)response.RawBytes;
+			}
+			else if (typeof(T).Name == "String") // for string response
+			{
+				response.Data = (T)(object)response.Content;
+			}
+
+			InterceptResponse(request, response);
+
+			var result = ToApiResponse(response);
+			if (response.ErrorMessage != null)
+			{
+				result.ErrorText = response.ErrorMessage;
+			}
+
+			if (response.Cookies != null && response.Cookies.Count > 0)
+			{
+				if (result.Cookies == null) result.Cookies = new List<Cookie>();
+				foreach (var restResponseCookie in response.Cookies.Cast<Cookie>())
+				{
+					var cookie = new Cookie(
+						restResponseCookie.Name,
+						restResponseCookie.Value,
+						restResponseCookie.Path,
+						restResponseCookie.Domain
+					)
+					{
+						Comment = restResponseCookie.Comment,
+						CommentUri = restResponseCookie.CommentUri,
+						Discard = restResponseCookie.Discard,
+						Expired = restResponseCookie.Expired,
+						Expires = restResponseCookie.Expires,
+						HttpOnly = restResponseCookie.HttpOnly,
+						Port = restResponseCookie.Port,
+						Secure = restResponseCookie.Secure,
+						Version = restResponseCookie.Version
+					};
+
+					result.Cookies.Add(cookie);
+				}
+			}
+			return result;
 		}
 
         private RestResponse<T> DeserializeRestResponseFromPolicy<T>(RestClient client, RestRequest request, PolicyResult<RestResponse> policyResult)
@@ -678,19 +688,15 @@ namespace IdeaStatiCa.ConnectionApi.Client
                 
         private ApiResponse<T> Exec<T>(RestRequest request, RequestOptions options, IReadableConfiguration configuration)
         {
-            Action<RestClientOptions> setOptions = (clientOptions) =>
+            if (options.Cookies != null && options.Cookies.Count > 0)
             {
-                var cookies = new CookieContainer();
-
-                if (options.Cookies != null && options.Cookies.Count > 0)
+                foreach (var cookie in options.Cookies)
                 {
-                    foreach (var cookie in options.Cookies)
-                    {
-                        cookies.Add(new Cookie(cookie.Name, cookie.Value));
-                    }
+                    request.AddCookie(cookie.Name, cookie.Value, "/", "");
                 }
-                clientOptions.CookieContainer = cookies;
-            };
+            }
+
+            Action<RestClientOptions> setOptions = (clientOptions) => { };
 
             Func<RestClient, RestResponse<T>> getResponse = (client) =>
             {

--- a/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ApiClientDisposalTests.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ApiClientDisposalTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using IdeaStatiCa.ConnectionApi.Client;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ST_ConRestApiClient
+{
+	/// <summary>
+	/// Tests that ApiClient properly reuses a single RestClient instance
+	/// instead of creating one per request (which causes TCP port exhaustion).
+	/// Bug #32846: TCP port exhaustion from disposed HttpClient/RestClient instances
+	/// leaving sockets in TIME_WAIT state.
+	/// </summary>
+	[TestFixture]
+	public class ApiClientDisposalTests
+	{
+		[Test]
+		public void ApiClient_Should_Implement_IDisposable()
+		{
+			// ApiClient must implement IDisposable so that callers can dispose
+			// the underlying RestClient when they are done, preventing socket leaks.
+			typeof(ApiClient).Should().Implement<IDisposable>(
+				"ApiClient owns an HttpClient via RestClient and must be disposable to prevent TCP port exhaustion");
+		}
+
+		[Test]
+		public void ApiClient_Should_Have_RestClient_Field_For_Reuse()
+		{
+			// ApiClient should hold a RestClient as a field (not create one per request).
+			// This ensures socket reuse across HTTP calls.
+			var restClientFields = typeof(ApiClient)
+				.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+				.Where(f => f.FieldType.Name == "RestClient")
+				.ToList();
+
+			restClientFields.Should().NotBeEmpty(
+				"ApiClient should hold a RestClient field for reuse across requests, " +
+				"instead of creating a new RestClient per request (causes TCP port exhaustion)");
+		}
+
+		[Test]
+		public void ApiClient_Dispose_Should_Dispose_RestClient()
+		{
+			// When ApiClient is disposed, the underlying RestClient should also be disposed.
+			var client = new ApiClient("http://localhost:5000");
+
+			var disposable = client as IDisposable;
+			disposable.Should().NotBeNull("ApiClient must implement IDisposable");
+
+			// Should not throw when disposing
+			Action dispose = () => disposable!.Dispose();
+			dispose.Should().NotThrow("disposing ApiClient should cleanly dispose the underlying RestClient");
+		}
+	}
+}


### PR DESCRIPTION
## Summary

  `ApiClient.ExecClient` and `ExecClientAsync` created a new `RestClient` (and internally `HttpClient`) for every REST call. On Windows,
  disposed `HttpClient` instances leave sockets in TIME_WAIT for ~240 seconds — under high throughput (e.g. ML Calculator processing
  hundreds of YAML files via LocalRunner), this exhausts ephemeral TCP ports and blocks all outbound connections.

  This caused the Prefect worker on HE-SOLVER-SRV to lose connectivity (114 late flow runs).

  ## Changes

  - **Reuse a single `RestClient`**: `ApiClient` now holds a lazily-created `RestClient` field (`_restClient`) with thread-safe
  initialization, reused across all `ExecClient`/`ExecClientAsync` calls
  - **Implement `IDisposable`**: callers can dispose the underlying `RestClient` (and its `HttpClient`) when done
  - **Move cookie handling to request level**: cookies from `RequestOptions` are now added to the `RestRequest` instead of
  `RestClientOptions`, since the client is no longer recreated per call

  ## Test plan

  - [x] `ApiClient_Should_Implement_IDisposable` — verifies IDisposable interface
  - [x] `ApiClient_Should_Have_RestClient_Field_For_Reuse` — verifies RestClient field exists
  - [x] `ApiClient_Dispose_Should_Dispose_RestClient` — verifies clean disposal

  ADO work item: #32846
  AI-assisted PR, human review required