### PR TITLE
#33325 Exclude import of walls during import of connections

### DIFF
--- a/src/IdeaStatiCa.BimImporter/BimImporter.cs
+++ b/src/IdeaStatiCa.BimImporter/BimImporter.cs
@@ -90,7 +90,7 @@ namespace IdeaStatiCa.BimImporter
 			_remoteApp?.SendMessageLocalised(MessageSeverity.Info, LocalisedMessage.ImportingConnections);
 
 			BulkSelection selection = InitBulkImport();
-			return ProcessSelectedModel(countryCode, selection);
+			return ProcessSelectedModel(countryCode, new BulkSelection(selection.Nodes, selection.Members, selection.ConnectionPoints));
 		}
 
 		private ModelBIM ProcessSelectedModel(CountryCode countryCode, BulkSelection selection)


### PR DESCRIPTION
Changes in BIM importer logic:
- exclude walls during import of connections 
