### PR TITLE
Switch all .NET 8 projects to .NET 10

### DIFF
--- a/.github/workflows/dotnet-artifacts.yml
+++ b/.github/workflows/dotnet-artifacts.yml
@@ -42,12 +42,12 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ConApiWpfClientApp
-        path: ${{ github.workspace }}/main/src/api-sdks/connection-api/clients/csharp/examples/ConApiWpfClient/ConApiWpfClientApp/bin/Release/net8.0-windows
+        path: ${{ github.workspace }}/main/src/api-sdks/connection-api/clients/csharp/examples/ConApiWpfClient/ConApiWpfClientApp/bin/Release/net10.0-windows
         if-no-files-found: error
 
     - name: 'Upload RcsApiWpfClientApp'
       uses: actions/upload-artifact@v4
       with:
         name: RcsApiWpfClientApp
-        path: ${{ github.workspace }}/main/src/api-sdks/rcs-api/clients/csharp/examples/RcsApiWpfClient/RcsApiWpfClientApp/bin/Release/net8.0-windows
+        path: ${{ github.workspace }}/main/src/api-sdks/rcs-api/clients/csharp/examples/RcsApiWpfClient/RcsApiWpfClientApp/bin/Release/net10.0-windows
         if-no-files-found: error

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main, release_* ]
 env:
-  DOTNET_VERSION: '9.0.301'
+  DOTNET_VERSION: '10.0.105'
   NUGET_BINARY_VERSION: '6.13.2'
 
 jobs:

--- a/examples/bimapi/CheckbotBimLink/BimLinkExampleRunner/BimLinkExampleRunner.csproj
+++ b/examples/bimapi/CheckbotBimLink/BimLinkExampleRunner/BimLinkExampleRunner.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
 		<UseWPF>true</UseWPF>
 		<ProjectGuid>{669835E3-E2A5-48E5-8CF4-752370CB7051}</ProjectGuid>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>

--- a/examples/bimapi/CheckbotBimLink/CadExample/BimApiLinkCadExample/BimApiLinkCadExample.csproj
+++ b/examples/bimapi/CheckbotBimLink/CadExample/BimApiLinkCadExample/BimApiLinkCadExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
     <Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>
   </PropertyGroup>
 

--- a/examples/bimapi/CheckbotBimLink/CadExample/CadBulkSelection/CadBulkSelection.csproj
+++ b/examples/bimapi/CheckbotBimLink/CadExample/CadBulkSelection/CadBulkSelection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>
 		<UseWPF>true</UseWPF>
 	</PropertyGroup>

--- a/examples/bimapi/CheckbotBimLink/CadExample/CadExampleApi/CadExampleApi.csproj
+++ b/examples/bimapi/CheckbotBimLink/CadExample/CadExampleApi/CadExampleApi.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/bimapi/CheckbotBimLink/CppFeaExample/CopyToOutputApp/CopyToOutputApp.csproj
+++ b/examples/bimapi/CheckbotBimLink/CppFeaExample/CopyToOutputApp/CopyToOutputApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/examples/bimapi/CheckbotBimLink/CppFeaExample/ImporterWrappers/ImporterWrappers.csproj
+++ b/examples/bimapi/CheckbotBimLink/CppFeaExample/ImporterWrappers/ImporterWrappers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/bimapi/CheckbotBimLink/FeaExample/BimApiLinkFeaExample/BimApiLinkFeaExample.csproj
+++ b/examples/bimapi/CheckbotBimLink/FeaExample/BimApiLinkFeaExample/BimApiLinkFeaExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>
 		<!--<Nullable>enable</Nullable>-->
 	</PropertyGroup>

--- a/examples/bimapi/CheckbotBimLink/FeaExample/FeaExampleApi/FeaExampleApi.csproj
+++ b/examples/bimapi/CheckbotBimLink/FeaExample/FeaExampleApi/FeaExampleApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/bimapi/CheckbotBimLink/SAF/CppSafFeaExample/CopyToOutputApp/CopyToOutputApp.csproj
+++ b/examples/bimapi/CheckbotBimLink/SAF/CppSafFeaExample/CopyToOutputApp/CopyToOutputApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/examples/bimapi/CheckbotBimLink/SAF/SafFeaBimLink/SafFeaBimLink.csproj
+++ b/examples/bimapi/CheckbotBimLink/SAF/SafFeaBimLink/SafFeaBimLink.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 	</PropertyGroup>

--- a/examples/bimapi/CheckbotBimLink/SAF/SafFeaExample/SafFeaApi_Mock/SafFeaApi_MOCK.csproj
+++ b/examples/bimapi/CheckbotBimLink/SAF/SafFeaExample/SafFeaApi_Mock/SafFeaApi_MOCK.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/bimapi/CheckbotBimLink/SAF/SafFeaExample/SafFeaTestApp/SafFeaTestApp.csproj
+++ b/examples/bimapi/CheckbotBimLink/SAF/SafFeaExample/SafFeaTestApp/SafFeaTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/examples/bimapi/SAF2IOM-WinForm-Tester/SAF2IOM/SAF2IOM.csproj
+++ b/examples/bimapi/SAF2IOM-WinForm-Tester/SAF2IOM/SAF2IOM.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+		<TargetFrameworks>net48;net10.0-windows</TargetFrameworks>
 		<UseWPF>true</UseWPF>
 		<PlatformTarget>x64</PlatformTarget>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>

--- a/examples/iom/csharp/ConnectionIomGenerator/ConnectionIomGenerator.UI/ConnectionIomGenerator.UI.csproj
+++ b/examples/iom/csharp/ConnectionIomGenerator/ConnectionIomGenerator.UI/ConnectionIomGenerator.UI.csproj
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>

--- a/examples/iom/csharp/ConnectionIomGenerator/ConnectionIomGenerator/ConnectionIomGenerator.csproj
+++ b/examples/iom/csharp/ConnectionIomGenerator/ConnectionIomGenerator/ConnectionIomGenerator.csproj
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>

--- a/examples/iom/csharp/ConnectionIomGenerator/ConnectionIomGeneratorApp/ConnectionIomGeneratorApp.csproj
+++ b/examples/iom/csharp/ConnectionIomGenerator/ConnectionIomGeneratorApp/ConnectionIomGeneratorApp.csproj
@@ -5,7 +5,7 @@
 	
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>

--- a/examples/iom/csharp/IomToRcsExamples/IomToRcsExampleRunner/IomToRcsExampleRunner.csproj
+++ b/examples/iom/csharp/IomToRcsExamples/IomToRcsExampleRunner/IomToRcsExampleRunner.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<OutputPath>bin\$(Configuration)\</OutputPath>

--- a/examples/iom/csharp/SteelFrameExample/IOM.SteelFrameDesktop/IOM.SteelFrameDesktop.csproj
+++ b/examples/iom/csharp/SteelFrameExample/IOM.SteelFrameDesktop/IOM.SteelFrameDesktop.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{AB4430E2-EAA3-4DE0-92C8-3298BB7A81C3}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>IOM.SteelFrameDesktop</AssemblyTitle>
     <Product>IOM.SteelFrameDesktop</Product>

--- a/src/CheckbotPlugins/ExamplePlugin/ExamplePlugin.csproj
+++ b/src/CheckbotPlugins/ExamplePlugin/ExamplePlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList.Tests/IdeaStatiCa.CheckbotPlugin.PluginList.Tests.csproj
+++ b/src/CheckbotPlugins/IdeaStatiCa.CheckbotPlugin.PluginList.Tests/IdeaStatiCa.CheckbotPlugin.PluginList.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\Common.props" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/src/Examples/CCM/FEAppExample_1/FEAppExample_1.csproj
+++ b/src/Examples/CCM/FEAppExample_1/FEAppExample_1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">  
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0-windows</TargetFrameworks>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>

--- a/src/Examples/CheckbotBimLink/BimLinkExampleConsoleApp/BimLinkExampleConsoleApp.csproj
+++ b/src/Examples/CheckbotBimLink/BimLinkExampleConsoleApp/BimLinkExampleConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0-windows;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IdeaStatiCa.BimApiLink/IdeaStatiCa.BimApiLink.csproj
+++ b/src/IdeaStatiCa.BimApiLink/IdeaStatiCa.BimApiLink.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>IdeaStatiCa;BIM;C#;FEA;IOM;IdeaOpenModel</PackageTags>
     <Configurations>Release;Debug;Debug_IdeaStatiCa_Internal;Release_IdeaStatiCa_Internal</Configurations>

--- a/src/IdeaStatiCa.BimImporter.Tests/IdeaStatiCa.BimImporter.Tests.csproj
+++ b/src/IdeaStatiCa.BimImporter.Tests/IdeaStatiCa.BimImporter.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net48; net8.0</TargetFrameworks>
+    <TargetFrameworks>net48; net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IdeaStatiCa.IOM.VersioningServiceTests/IdeaStatiCa.IOM.VersioningServiceTests.csproj
+++ b/src/IdeaStatiCa.IOM.VersioningServiceTests/IdeaStatiCa.IOM.VersioningServiceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\Common.props" />
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 

--- a/src/IdeaStatiCa.IntermediateModel.Tests/IdeaStatiCa.IntermediateModel.Tests.csproj
+++ b/src/IdeaStatiCa.IntermediateModel.Tests/IdeaStatiCa.IntermediateModel.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\Common.props" />
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 

--- a/src/IdeaStatiCa.ItemsSorter/IdeaStatiCa.ItemsSorter.csproj
+++ b/src/IdeaStatiCa.ItemsSorter/IdeaStatiCa.ItemsSorter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+		<TargetFrameworks>net48;net10.0-windows</TargetFrameworks>
 		<UseWPF>true</UseWPF>
 	</PropertyGroup>
 

--- a/src/IdeaStatiCa.Plugin.Tests/IdeaStatiCa.Plugin.Tests.csproj
+++ b/src/IdeaStatiCa.Plugin.Tests/IdeaStatiCa.Plugin.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net48; net8.0</TargetFrameworks>
+    <TargetFrameworks>net48; net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IdeaStatiCa.PluginsTools.Windows/IdeaStatiCa.PluginsTools.Windows.csproj
+++ b/src/IdeaStatiCa.PluginsTools.Windows/IdeaStatiCa.PluginsTools.Windows.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0-windows</TargetFrameworks>
     <AssemblyTitle>IdeaStatiCa.PluginsTools.Windows</AssemblyTitle>
     <Product>IdeaStatiCa.PluginsTools.Windows</Product>
   </PropertyGroup>

--- a/src/IdeaStatiCa.PluginsTools/IdeaStatiCa.PluginsTools.csproj
+++ b/src/IdeaStatiCa.PluginsTools/IdeaStatiCa.PluginsTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\Common.props" />
 	<PropertyGroup>
-		<TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+		<TargetFrameworks>net48;net10.0-windows</TargetFrameworks>
 		<AssemblyTitle>IdeaStatiCa.PluginsTools</AssemblyTitle>
 		<Product>IdeaStatiCa.PluginsTools</Product>
 		<LangVersion>8.0</LangVersion>
@@ -23,16 +23,16 @@
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug_IdeaStatiCa_Internal|net48|AnyCPU'">
 	  <WarningsNotAsErrors>$(WarningsNotAsErrors);8073</WarningsNotAsErrors>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows|AnyCPU'">
 	  <WarningsNotAsErrors>$(WarningsNotAsErrors);8073</WarningsNotAsErrors>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-windows|AnyCPU'">
 	  <WarningsNotAsErrors>$(WarningsNotAsErrors);8073</WarningsNotAsErrors>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release_IdeaStatiCa_Internal|net8.0-windows|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release_IdeaStatiCa_Internal|net10.0-windows|AnyCPU'">
 	  <WarningsNotAsErrors>$(WarningsNotAsErrors);8073</WarningsNotAsErrors>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug_IdeaStatiCa_Internal|net8.0-windows|AnyCPU'">
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug_IdeaStatiCa_Internal|net10.0-windows|AnyCPU'">
 	  <WarningsNotAsErrors>$(WarningsNotAsErrors);8073</WarningsNotAsErrors>
 	</PropertyGroup>
 	

--- a/src/SystemTests/SystemTestService/SystemTestService.csproj
+++ b/src/SystemTests/SystemTestService/SystemTestService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48; net8.0</TargetFrameworks>
+    <TargetFrameworks>net48; net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/api-sdks/connection-api/clients/csharp/examples/CalculationBulkTool/CalculationBulkTool.csproj
+++ b/src/api-sdks/connection-api/clients/csharp/examples/CalculationBulkTool/CalculationBulkTool.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>

--- a/src/api-sdks/connection-api/clients/csharp/examples/CodeSamples/CodeSamples.csproj
+++ b/src/api-sdks/connection-api/clients/csharp/examples/CodeSamples/CodeSamples.csproj
@@ -5,7 +5,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>

--- a/src/api-sdks/connection-api/clients/csharp/examples/ConApiWpfClient/ConApiWpfClientApp/ConApiWpfClientApp.csproj
+++ b/src/api-sdks/connection-api/clients/csharp/examples/ConApiWpfClient/ConApiWpfClientApp/ConApiWpfClientApp.csproj
@@ -5,7 +5,7 @@
 	
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>

--- a/src/api-sdks/connection-api/clients/csharp/examples/ConversionBulkTool/ConversionBulkTool.csproj
+++ b/src/api-sdks/connection-api/clients/csharp/examples/ConversionBulkTool/ConversionBulkTool.csproj
@@ -5,7 +5,7 @@
 	
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>

--- a/src/api-sdks/connection-api/clients/csharp/examples/PublishBulkTool/PublishBulkTool.csproj
+++ b/src/api-sdks/connection-api/clients/csharp/examples/PublishBulkTool/PublishBulkTool.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ApiExt/ExportApiExt.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ApiExt/ExportApiExt.cs
@@ -40,7 +40,7 @@ namespace IdeaStatiCa.ConnectionApi.Api
 			string ifc = (string)response.Data;
 
 			// Write the string to the file
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 			await File.AppendAllTextAsync(filePath, ifc);
 #else
 			File.WriteAllText(filePath, ifc);

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ApiExt/ProjectApiExt.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ApiExt/ProjectApiExt.cs
@@ -100,7 +100,7 @@ namespace IdeaStatiCa.ConnectionApi.Api
 		public async Task<ConProject> CreateProjectFromIomFileAsync(string fileName, List<int> connectionsToCreate = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
 		{
 			string xmlString = string.Empty;
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 			xmlString = await System.IO.File.ReadAllTextAsync(fileName);
 #else
 			xmlString = System.IO.File.ReadAllText(fileName);
@@ -121,7 +121,7 @@ namespace IdeaStatiCa.ConnectionApi.Api
 		public async Task<ConProject> UpdateProjectFromIomFileAsync(Guid projectId, string iomFilePath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
 		{
 			string xmlString = string.Empty;
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 			xmlString = await System.IO.File.ReadAllTextAsync(iomFilePath);
 #else
 			xmlString = System.IO.File.ReadAllText(iomFilePath);

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/IConnectionApiClient.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/IConnectionApiClient.cs
@@ -8,7 +8,7 @@ namespace IdeaStatiCa.ConnectionApi
 	/// Client for accessing IdeaStatiCa.ConnectionRestApi
 	/// </summary>
 	public interface IConnectionApiClient : IApiClient
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 		, IAsyncDisposable
 #endif
 	{

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/IdeaStatiCa.ConnectionApi.csproj
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/IdeaStatiCa.ConnectionApi.csproj
@@ -28,6 +28,10 @@
     <PackageReference Include="Polly"/>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\..\IdeaRS.OpenModel\IdeaRS.OpenModel.csproj" />
     <ProjectReference Include="..\..\..\..\..\..\IdeaStatiCa.Api\IdeaStatiCa.Api.csproj" />

--- a/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ST_ConRestApiClient.csproj
+++ b/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ST_ConRestApiClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 

--- a/src/api-sdks/rcs-api/clients/csharp/examples/CodeSamples/CodeSamples.csproj
+++ b/src/api-sdks/rcs-api/clients/csharp/examples/CodeSamples/CodeSamples.csproj
@@ -5,7 +5,7 @@
 	
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 	</PropertyGroup>

--- a/src/api-sdks/rcs-api/clients/csharp/examples/RcsApiWpfClient/RcsApiWpfClientApp/RcsApiWpfClientApp.csproj
+++ b/src/api-sdks/rcs-api/clients/csharp/examples/RcsApiWpfClient/RcsApiWpfClientApp/RcsApiWpfClientApp.csproj
@@ -5,7 +5,7 @@
 	
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
 		<Configurations>Debug;Release;Debug_NuGet;Release_NuGet</Configurations>

--- a/src/api-sdks/rcs-api/clients/csharp/src/IdeaStatiCa.RcsApi/IRcsApiClient.cs
+++ b/src/api-sdks/rcs-api/clients/csharp/src/IdeaStatiCa.RcsApi/IRcsApiClient.cs
@@ -8,7 +8,7 @@ namespace IdeaStatiCa.RcsApi
 	/// Client for accessing IdeaStatiCa.ConnectionRestApi
 	/// </summary>
 	public interface IRcsApiClient : IApiClient
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET5_0_OR_GREATER
 		, IAsyncDisposable
 #endif
 	{

--- a/src/api-sdks/rcs-api/clients/csharp/src/IdeaStatiCa.RcsApi/IdeaStatiCa.RcsApi.csproj
+++ b/src/api-sdks/rcs-api/clients/csharp/src/IdeaStatiCa.RcsApi/IdeaStatiCa.RcsApi.csproj
@@ -28,6 +28,10 @@
     <PackageReference Include="Polly"/>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\..\IdeaRS.OpenModel\IdeaRS.OpenModel.csproj" />
     <ProjectReference Include="..\..\..\..\..\..\IdeaStatiCa.Api\IdeaStatiCa.Api.csproj" />

--- a/src/api-sdks/rcs-api/clients/csharp/src/tests/ST_RcsRestApiClient/ST_RcsRestApiClient.csproj
+++ b/src/api-sdks/rcs-api/clients/csharp/src/tests/ST_RcsRestApiClient/ST_RcsRestApiClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 

--- a/src/bim-links/bentley-ram/IdeaStatiCa.Ram25ToIdea/IdeaStatiCa.Ram25ToIdea.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.Ram25ToIdea/IdeaStatiCa.Ram25ToIdea.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\Common.props" />
   <PropertyGroup>
     <ProjectGuid>{881C74B0-CF8E-4911-9FB1-7DF91AF04036}</ProjectGuid>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Configurations>Debug;Release;Debug_IdeaStatiCa_Internal;Release_IdeaStatiCa_Internal</Configurations>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/src/bim-links/bentley-ram/IdeaStatiCa.Ram25ToIdeaApp/IdeaStatiCa.Ram25ToIdeaApp.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.Ram25ToIdeaApp/IdeaStatiCa.Ram25ToIdeaApp.csproj
@@ -2,7 +2,7 @@
 	<Import Project="..\..\..\Common.props" />
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Configurations>Debug;Release;Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal</Configurations>
 		<UseWPF>true</UseWPF>
 		<ApplicationIcon>Resources\RAM icon.ico</ApplicationIcon>

--- a/src/bim-links/bentley-ram/IdeaStatiCa.Ram25ToIdeaApp/Services/FolderHelper.cs
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.Ram25ToIdeaApp/Services/FolderHelper.cs
@@ -38,8 +38,8 @@ namespace IdeaStatiCa.RamToIdeaApp.Services
 				return foundLocation;
 			}
 
-			//is the file is in net8.0-windows subdir ?
-			foundLocation = Path.Combine(rootFolder, "net8.0-windows", file);
+			//is the file is in net10.0-windows subdir ?
+			foundLocation = Path.Combine(rootFolder, "net10.0-windows", file);
 			if (File.Exists(foundLocation))
 			{
 				ideaLogger.LogDebug($"FindNetFolder : found in '{foundLocation}'");
@@ -77,8 +77,8 @@ namespace IdeaStatiCa.RamToIdeaApp.Services
 					return foundLocation;
 				}
 
-				//is the file is in net8.0-windows subdir ?
-				foundLocation = Path.Combine(rootFolderDeve, "net8.0-windows", file);
+				//is the file is in net10.0-windows subdir ?
+				foundLocation = Path.Combine(rootFolderDeve, "net10.0-windows", file);
 				if (File.Exists(foundLocation))
 				{
 					ideaLogger.LogDebug($"FindNetFolder : found in '{foundLocation}'");

--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamContracts/IdeaStatiCa.RamContracts.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamContracts/IdeaStatiCa.RamContracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="..\..\..\Common.props" />
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
 	<Configurations>Debug;Release;Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal</Configurations>
 	<Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdea/IdeaStatiCa.RamToIdea.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdea/IdeaStatiCa.RamToIdea.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\Common.props" />
   <PropertyGroup>
     <ProjectGuid>{ec8df878-7ce5-458d-bf3e-fec30768a104}</ProjectGuid>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Configurations>Debug;Release;Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal</Configurations>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaApp/IdeaStatiCa.RamToIdeaApp.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaApp/IdeaStatiCa.RamToIdeaApp.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\Common.props" />
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Configurations>Debug;Release;Debug_IdeaStatiCa_Internal;Release_IdeaStatiCa_Internal</Configurations>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Resources\RAM icon.ico</ApplicationIcon>

--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaApp/Services/FolderHelper.cs
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaApp/Services/FolderHelper.cs
@@ -38,8 +38,8 @@ namespace IdeaStatiCa.RamToIdeaApp.Services
 				return foundLocation;
 			}
 
-			//is the file is in net8.0-windows subdir ?
-			foundLocation = Path.Combine(rootFolder, "net8.0-windows", file);
+			//is the file is in net10.0-windows subdir ?
+			foundLocation = Path.Combine(rootFolder, "net10.0-windows", file);
 			if (File.Exists(foundLocation))
 			{
 				ideaLogger.LogDebug($"FindNetFolder : found in '{foundLocation}'");
@@ -77,8 +77,8 @@ namespace IdeaStatiCa.RamToIdeaApp.Services
 					return foundLocation;
 				}
 
-				//is the file is in net8.0-windows subdir ?
-				foundLocation = Path.Combine(rootFolderDeve, "net8.0-windows", file);
+				//is the file is in net10.0-windows subdir ?
+				foundLocation = Path.Combine(rootFolderDeve, "net10.0-windows", file);
 				if (File.Exists(foundLocation))
 				{
 					ideaLogger.LogDebug($"FindNetFolder : found in '{foundLocation}'");

--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaTest/IdeaStatiCa.RamToIdeaTest.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamToIdeaTest/IdeaStatiCa.RamToIdeaTest.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\Common.props" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Platforms>x64</Platforms>
   </PropertyGroup>

--- a/src/bim-links/rstab/IdeaRstabPlugin/IdeaRstabPlugin.csproj
+++ b/src/bim-links/rstab/IdeaRstabPlugin/IdeaRstabPlugin.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\Common.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0-windows</TargetFrameworks>
     <Configurations>Debug;Release;Release_IdeaStatiCa_Internal;Debug_IdeaStatiCa_Internal</Configurations>
     <Platforms>x64</Platforms>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCaClient.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCaClient.cs
@@ -141,18 +141,18 @@ namespace IdeaStatiCa.TeklaStructuresPlugin
 
 				if (!File.Exists(checkbotLocation))
 				{
-					//checkbot app is in net8.0-windows folder and teklaPlugin is in base of setup
-					checkbotLocation = Path.Combine(checkbotRoot, "net8.0-windows", IdeaStatiCa.Plugin.Constants.CheckbotAppName);
+					//checkbot app is in net10.0-windows folder and teklaPlugin is in base of setup
+					checkbotLocation = Path.Combine(checkbotRoot, "net10.0-windows", IdeaStatiCa.Plugin.Constants.CheckbotAppName);
 				}
 
 				if (!File.Exists(checkbotLocation))
 				{
-					//checkbot app is in net8.0-windows folder and teklaPlugin is in net48  of setup
-					checkbotLocation = Path.Combine(checkbotRoot, "..\\net8.0-windows", IdeaStatiCa.Plugin.Constants.CheckbotAppName);
+					//checkbot app is in net10.0-windows folder and teklaPlugin is in net48  of setup
+					checkbotLocation = Path.Combine(checkbotRoot, "..\\net10.0-windows", IdeaStatiCa.Plugin.Constants.CheckbotAppName);
 				}
 				if (!File.Exists(checkbotLocation))
 				{
-					//checkbot app is in net48 folder and teklaPlugin is in net8.0-windows  of setup
+					//checkbot app is in net48 folder and teklaPlugin is in net10.0-windows  of setup
 					checkbotLocation = Path.Combine(checkbotRoot, "..\\net48", IdeaStatiCa.Plugin.Constants.CheckbotAppName);
 				}
 

--- a/tools/DotnetBuildTools/DotnetBuildTools.csproj
+++ b/tools/DotnetBuildTools/DotnetBuildTools.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- Replace net8.0/net8.0-windows with net10.0/net10.0-windows across all csproj files
- Update hardcoded net8.0 paths in source code (.cs files)
- Update GitHub Actions workflow

Part of IdeaStatiCa#33263 (.NET 10 migration).

AI-assisted PR, human review required