### PR TITLE
Allow parameter based build for GenerateAssemblyInfo

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == ''">true</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
This change will allow switching GenerateAssemblyInfo property on demand