### PR TITLE
CI: trigger .NET build verification on main_* branches

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,8 +1,10 @@
 name: .NET build verification
 
 on:
+  push:
+    branches: [ main_* ]
   pull_request:
-    branches: [ main, release_* ]
+    branches: [ main, main_*, release_* ]
 env:
   DOTNET_VERSION: '9.0.301'
   NUGET_BINARY_VERSION: '6.13.2'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET build verification
 
 on:
   push:
-    branches: [ main_* ]
+    branches: [ main, main_* ]
   pull_request:
     branches: [ main, main_*, release_* ]
 env:


### PR DESCRIPTION
## Summary

Add `main_*` to `pull_request.branches` and add a `push` trigger for `main_*` so commits landing on parallel-track branches (e.g. `main_net10`) produce a `'GitHub Actions'` check suite.

## Why

The IdeaStatiCa main repo (private, on Azure DevOps) consumes this repository as a submodule. The ADO Primary Pipeline runs a step **"Verify if build of submodule was successful on GitHub"** (`Pipeline-Tools/Scripts/CheckGithubActionsStatus`) that polls
`https://api.github.com/repos/idea-statica/ideastatica-public/commits/<sha>/check-suites`
and requires a check suite where `app.name == "GitHub Actions"` exists with `conclusion == "success"`.

Today the `.NET build verification` workflow only triggers on PRs targeting `main` or `release_*`. Any submodule pointer on a `main_*` branch (e.g. `main_net10` for the .NET 10 migration track) has no `'GitHub Actions'` check suite, and the ADO build fails with `The check suite with name 'GitHub Actions' was not found`.

Observed in IdeaStatiCa ADO build [#491444](https://dev.azure.com/ideastatica/IdeaStatiCa/_build/results?buildId=491444).

## Change

```diff
 on:
+  push:
+    branches: [ main_* ]
   pull_request:
-    branches: [ main, release_* ]
+    branches: [ main, main_*, release_* ]
```

- `pull_request: main_*` — PRs targeting `main_net10` (and any future `main_*` track) trigger the workflow before merge.
- `push: main_*` — commits landing on `main_*` get a check suite, regardless of merge strategy in the consumer's PR.

## Risk

- No change to existing behavior for `main` / `release_*`.
- New triggers only run for `main_*` branches, which today is just `main_net10`. Workers/runners are GitHub-hosted, so cost is bounded by branch activity.
