### PR TITLE
Bump Google.Protobuf + Grpc.* to match main-repo Story D (ADO #33622)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,13 +46,13 @@
     <PackageVersion Include="MathNet.Numerics" Version="5.0.0" />
     <PackageVersion Include="MathNet.Spatial" Version="0.6.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-    <PackageVersion Include="Grpc.Core" Version="2.46.3" />
-    <PackageVersion Include="Grpc.Core.Api" Version="2.71.0" />
+    <PackageVersion Include="Grpc.Core" Version="2.46.6" />
+    <PackageVersion Include="Grpc.Core.Api" Version="2.76.0" />
     <!--    <PackageVersion Include="Grpc.Core" Version="2.46.6" />-->
     <!--    <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />-->
     <!--    <PackageVersion Include="Grpc.Tools" Version="2.72.0" />-->
-    <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.46.3" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <PackageVersion Include="ini-parser" Version="2.5.2" />
     <PackageVersion Include="morelinq" Version="4.4.0" />
     <PackageVersion Include="Polly" Version="8.6.2" />
@@ -70,7 +70,7 @@
     <PackageVersion Include="Tekla.Structures.Dialog" Version="2024.0.0" />
     <PackageVersion Include="Tekla.Structures.Plugins" Version="2024.0.0" />
     <PackageVersion Include="TeklaOpenAPI" Version="2020.0.2" /> -->
-    <PackageVersion Include="Google.Protobuf" Version="3.30.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
     <PackageVersion Include="Castle.Windsor" Version="6.0.0" />
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="PropertyChanged.Fody" Version="4.1.0" />


### PR DESCRIPTION
## Summary

Main-repo ADO PR [#25308](https://dev.azure.com/ideastatica/IdeaStatiCa/_git/IdeaStatiCa/pullrequest/25308) (work item [#33622](https://dev.azure.com/ideastatica/IdeaStatiCa/_workitems/edit/33622)) bumps the Grpc / Google.Protobuf group in `Directory.Packages.props` as phase-I Story D of the .NET 10 NuGet upgrade. The main-repo Primary Pipeline fails on `CheckbotPluginTest.IomReceivedByPlugin` with `FileNotFoundException: Google.Protobuf 3.34.1.0` because this submodule's assemblies are compiled against 3.30.0 while main-repo callers expect 3.34.1 at runtime.

## Changes

- `Google.Protobuf` 3.30.0 → 3.34.1
- `Grpc.Core` 2.46.3 → 2.46.6
- `Grpc.Core.Api` 2.71.0 → 2.76.0
- `Grpc.Net.Client` 2.71.0 → 2.76.0
- `Grpc.Tools` 2.46.3 → 2.80.0

## Test plan

- [x] GitHub Actions `.NET build verification` green
- Post-merge: main-repo submodule pointer bumped to this PR's head SHA on `us/33622-grpc-incremental`; ADO Primary Pipeline re-runs and passes