### PR TITLE
Remove prunable dependency (#33719)

### DIFF
--- a/src/bim-links/bentley-ram/IdeaStatiCa.RamContracts/IdeaStatiCa.RamContracts.csproj
+++ b/src/bim-links/bentley-ram/IdeaStatiCa.RamContracts/IdeaStatiCa.RamContracts.csproj
@@ -7,10 +7,9 @@
   </PropertyGroup>
 
 	<!-- Set OutputPath for *_Internal configurations -->
-	
+
 	<ItemGroup>
 		<PackageReference Include="Autofac" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 		<PackageReference Include="Idea.Bentley.Ram" />
 		<PackageReference Include="MathNet.Numerics" />


### PR DESCRIPTION
Removes a prunable dependency from IdeaStatiCa.RamContracts.csproj to avoid NU1510 warning.