### PR TITLE
#33552 Correctly save newly created sections

### DIFF
--- a/src/IdeaStatiCa.BimApiLink/Results/InternalForcesBuilder.cs
+++ b/src/IdeaStatiCa.BimApiLink/Results/InternalForcesBuilder.cs
@@ -34,6 +34,7 @@ namespace IdeaStatiCa.BimApiLink.Results
 				_resultsData.Add(new ResultsData<T>(obj, result));
 
 				sections = new Sections(loadCase, result);
+				_sections[(obj.Id, loadCase.Id)] = sections;
 			}
 
 			return sections;


### PR DESCRIPTION
InternalForcesBuilder was incorrectly creating always new sections list, because created instance was not correctly stored internally.