### PR TITLE
Add SaveDesignItemPicture helper to ConnectionLibrary SDKs

### DIFF
--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ApiExt/ConnectionLibraryApiExt.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ApiExt/ConnectionLibraryApiExt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace IdeaStatiCa.ConnectionApi.Api
@@ -20,6 +21,17 @@ namespace IdeaStatiCa.ConnectionApi.Api
 		/// cref="System.Threading.CancellationToken.None"/>.</param>
 		/// <returns>A task that represents the asynchronous operation. The task result contains a byte array of the picture data.</returns>
 		Task<byte[]> GetDesignItemPictureDataAsync(Guid designSetId, Guid designItemId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+		/// <summary>
+		/// Asynchronously downloads the picture (PNG) for a specified design item and saves it to a file.
+		/// </summary>
+		/// <param name="designSetId">The unique identifier of the design set.</param>
+		/// <param name="designItemId">The unique identifier of the design item for which the picture is requested.</param>
+		/// <param name="filePath">The full path to the PNG file which will be created (or overwritten).</param>
+		/// <param name="cancellationToken">A token to monitor for cancellation requests. The default value is <see
+		/// cref="System.Threading.CancellationToken.None"/>.</param>
+		/// <returns>A task that represents the asynchronous file write operation.</returns>
+		Task SaveDesignItemPictureAsync(Guid designSetId, Guid designItemId, string filePath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 	}
 
 	/// <summary>
@@ -43,5 +55,22 @@ namespace IdeaStatiCa.ConnectionApi.Api
 			return buffer;
 		}
 
+		/// <inheritdoc cref="IConnectionLibraryApiExt.SaveDesignItemPictureAsync(Guid, Guid, string, System.Threading.CancellationToken)"/>
+		public async Task SaveDesignItemPictureAsync(Guid designSetId, Guid designItemId, string filePath, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+		{
+			byte[] buffer = await GetDesignItemPictureDataAsync(designSetId, designItemId, cancellationToken);
+
+			string directory = Path.GetDirectoryName(filePath);
+			if (!string.IsNullOrEmpty(directory))
+			{
+				Directory.CreateDirectory(directory);
+			}
+
+#if NETSTANDARD2_1_OR_GREATER
+			await File.WriteAllBytesAsync(filePath, buffer, cancellationToken);
+#else
+			File.WriteAllBytes(filePath, buffer);
+#endif
+		}
 	}
 }

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/api_ext/__init__.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/api_ext/__init__.py
@@ -1,1 +1,2 @@
 from ideastatica_connection_api.api_ext.project_ext_api import ProjectExtApi
+from ideastatica_connection_api.api_ext.connection_library_ext_api import ConnectionLibraryExtApi

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/api_ext/connection_library_ext_api.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/api_ext/connection_library_ext_api.py
@@ -1,0 +1,42 @@
+import os
+
+from ideastatica_connection_api.api.connection_library_api import ConnectionLibraryApi
+
+
+class ConnectionLibraryExtApi(ConnectionLibraryApi):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+    def save_design_item_picture(self, design_set_id: str, design_item_id: str, file_name: str):
+        """
+        Downloads the picture (PNG) for a given design item and saves it to the specified file.
+
+        Args:
+            design_set_id (str): The unique identifier of the design set.
+            design_item_id (str): The unique identifier of the design item for which the picture is requested.
+            file_name (str): The full path of the PNG file to write (will be created or overwritten).
+
+        Returns:
+            None
+        """
+
+        response = super().get_design_item_picture_with_http_info(
+            design_set_id=design_set_id,
+            design_item_id=design_item_id,
+        )
+
+        png_bytes = response.raw_data
+
+        if not png_bytes:
+            raise RuntimeError("Picture response is empty.")
+
+        if not png_bytes.startswith(b"\x89PNG"):
+            raise RuntimeError("Picture response is not PNG data.")
+
+        directory = os.path.dirname(file_name)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+
+        with open(file_name, 'wb') as file:
+            file.write(png_bytes)

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_client.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_client.py
@@ -6,6 +6,7 @@ import ideastatica_connection_api.api_client as api_client
 import ideastatica_connection_api.api_ext.project_ext_api as project_ext_api
 import ideastatica_connection_api.api_ext.export_ext_api as export_ext_api
 import ideastatica_connection_api.api_ext.report_ext_api as report_ext_api
+import ideastatica_connection_api.api_ext.connection_library_ext_api as connection_library_ext_api
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ class ConnectionApiClient:
 
         self.calculation: Optional[CalculationApi] = None
         self.connection: Optional[ConnectionApi] = None
-        self.connection_library: Optional[ConnectionLibraryApi] = None
+        self.connection_library: Optional[connection_library_ext_api.ConnectionLibraryExtApi] = None
         self.export: Optional[export_ext_api.ExportExtApi] = None
         self.load_effect: Optional[LoadEffectApi] = None
         self.material: Optional[MaterialApi] = None
@@ -48,7 +49,7 @@ class ConnectionApiClient:
 
         self.calculation = CalculationApi(self.client)
         self.connection = ConnectionApi(self.client)
-        self.connection_library = ConnectionLibraryApi(self.client)
+        self.connection_library = connection_library_ext_api.ConnectionLibraryExtApi(self.client)
         self.export = export_ext_api.ExportExtApi(self.client)
         self.load_effect = LoadEffectApi(self.client)
         self.material = MaterialApi(self.client)


### PR DESCRIPTION
Wraps the get-picture endpoint with a file-saving helper for both C# (SaveDesignItemPictureAsync) and Python (save_design_item_picture), mirroring ExportApiExt.ExportIfcFileAsync.
