### PR TITLE
#33733 Add IsUserEdited flag to ConnectedMember for CAD sync

### DIFF
--- a/examples/bimapi/CheckbotBimLink/BimLinkExampleRunner/BimLinkExampleRunner.csproj
+++ b/examples/bimapi/CheckbotBimLink/BimLinkExampleRunner/BimLinkExampleRunner.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" />
-		<PackageReference Include="PropertyChanged.Fody" />
+		<PackageReference Include="PropertyChanged.Fody" PrivateAssets="All" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/examples/iom/csharp/SteelFrameExample/IOM.SteelFrameWeb/IOM.SteelFrameWeb.csproj
+++ b/examples/iom/csharp/SteelFrameExample/IOM.SteelFrameWeb/IOM.SteelFrameWeb.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{DA9CE85E-7B4D-408B-9116-53A5918CAD1A}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net60</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>IOM.SteelFrame</AssemblyTitle>
     <Product>IOM.SteelFrame</Product>

--- a/src/IdeaRS.OpenModel/Connection/ConnectedMember.cs
+++ b/src/IdeaRS.OpenModel/Connection/ConnectedMember.cs
@@ -26,5 +26,13 @@
 		/// Length of the member
 		/// </summary>
 		public double Length { get; set; }
+
+		/// <summary>
+		/// True when this connected member was manually added or kept by the user in Checkbot
+		/// (not from the original CAD/BIM import). The flag is preserved across CAD/FEA Sync so
+		/// the user's choice survives re-import from the source model. Default false (CAD-imported).
+		/// Introduced in IOM 3.3.0 (US 33733).
+		/// </summary>
+		public bool IsUserEdited { get; set; }
 	}
 }

--- a/src/IdeaStatiCa.BimImporter/ImportedObjects/ConnectionPoint.cs
+++ b/src/IdeaStatiCa.BimImporter/ImportedObjects/ConnectionPoint.cs
@@ -11,7 +11,13 @@ namespace IdeaStatiCa.BimImporter.ImportedObjects
 	{
 		public string Id => "$connection-" + Node.Id;
 
-		public string Name => Node.Name;
+		// Auto-created connection points (from Connection.FromNodeAndMembers) inherit their name from the
+		// underlying node. Plugin link implementations often set Node.Name to a coordinate-encoded id
+		// (e.g. AdvanceSteel sets Name = id.ToString() which is the "X;Y;Z" GetPointId string), and that
+		// would propagate into IOM ConnectionPoint.Name, bypassing BimImporter.ImportContext fallback
+		// `cp.Name = $"C {cp.Id}"`. Return null so the fallback applies and synthetic connection points
+		// get clean user-facing labels (`C 452`, etc.) in Checkbot. Bug from #34xxx.
+		public string Name => null;
 
 		public IIdeaNode Node { get; }
 

--- a/src/IdeaStatiCa.IOM.VersioningService/Configuration/ConfigurationStepService.cs
+++ b/src/IdeaStatiCa.IOM.VersioningService/Configuration/ConfigurationStepService.cs
@@ -29,6 +29,7 @@ namespace IdeaStatiCa.IOM.VersioningService.Configuration
 			RegisterStep(new Step300(_logger));
 			RegisterStep(new Step310(_logger));
 			RegisterStep(new Step320(_logger));
+			RegisterStep(new Step330(_logger));
 		}
 
 		private void RegisterStep(BaseStep step)

--- a/src/IdeaStatiCa.IOM.VersioningService/VersionSteps/Steps/Step3_3_0.cs
+++ b/src/IdeaStatiCa.IOM.VersioningService/VersionSteps/Steps/Step3_3_0.cs
@@ -1,0 +1,59 @@
+using IdeaStatiCa.IntermediateModel.Extensions;
+using IdeaStatiCa.IntermediateModel.IRModel;
+using IdeaStatiCa.IOM.VersioningService.Extension;
+using IdeaStatiCa.Plugin;
+using System;
+using System.Linq;
+
+namespace IdeaStatiCa.IOM.VersioningService.VersionSteps.Steps
+{
+	/// <summary>
+	/// US 33733 — IOM 3.3.0 added IdeaRS.OpenModel.Connection.ConnectedMember.IsUserEdited.
+	/// Upgrade is a no-op (DataContractSerializer treats missing element as default false).
+	/// Downgrade strips the property so consumers on &lt; 3.3.0 don't see an unknown element.
+	/// </summary>
+	internal class Step330 : BaseStep
+	{
+		public Step330(IPluginLogger logger) : base(logger)
+		{
+		}
+
+		public static Version Version => Version.Parse("3.3.0");
+
+		public override Version GetVersion() => Step330.Version;
+
+		public override void DoDownStep(SModel _model)
+		{
+			ISIntermediate openModel = _model.GetModelElement();
+			if (openModel == null)
+			{
+				_logger.LogInformation($"OpenModel not found. DownStep {Version} was skipped");
+				return;
+			}
+
+			DowngradeConnectedMembers(openModel);
+		}
+
+		public override void DoUpStep(SModel _model)
+		{
+			// No-op: DataContractSerializer assigns default(false) when IsUserEdited is missing
+			// from a pre-3.3.0 XML, which matches "CAD-imported, never user-edited" semantics.
+		}
+
+		private void DowngradeConnectedMembers(ISIntermediate openModel)
+		{
+			var connectedMembers = openModel
+				.GetElements("Connections;ConnectionData;ConnectedBeams;ConnectedMember")
+				?.ToList();
+			if (connectedMembers == null)
+			{
+				return;
+			}
+
+			foreach (SObject cm in connectedMembers.OfType<SObject>())
+			{
+				cm.RemoveElementProperty("IsUserEdited");
+			}
+		}
+	}
+}

--- a/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/CHKUpgraded.xml
+++ b/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/CHKUpgraded.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-16"?>
 <OpenModelContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<OpenModel>
-		<Version>3.2.0</Version>
+		<Version>3.3.0</Version>
 		<OriginSettings>
 			<ProjectName>CON1</ProjectName>
 			<DateOfCreate>2024-07-26T14:17:22.6769215+02:00</DateOfCreate>

--- a/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/LoadOnSurface_3_0_0.xml
+++ b/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/LoadOnSurface_3_0_0.xml
@@ -4,7 +4,7 @@
   <RequestedItems>Members2D</RequestedItems>
   <Items />
   <Model>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <OriginSettings>
       <DateOfCreate>0001-01-01T00:00:00</DateOfCreate>
       <CrossSectionConversionTable>NoUsed</CrossSectionConversionTable>

--- a/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/OpenModel-Bug24049Upgraded.xml
+++ b/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/OpenModel-Bug24049Upgraded.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-16"?>
 <OpenModelContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<OpenModel>
-		<Version>3.2.0</Version>
+		<Version>3.3.0</Version>
 		<OriginSettings>
 			<ProjectName>idea</ProjectName>
 			<DateOfCreate>0001-01-01T00:00:00</DateOfCreate>

--- a/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/OpenModel-LargeUpgraded.xml
+++ b/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/OpenModel-LargeUpgraded.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-16"?>
 <OpenModel xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<Version>3.2.0</Version>
+	<Version>3.3.0</Version>
 	<OriginSettings>
 		<ProjectName>23070 -  HWP</ProjectName>
 		<ProjectDescription>23070_10000_0706_001</ProjectDescription>

--- a/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/OpenModel-NOoriginalModelIdUpgraded.xml
+++ b/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/OpenModel-NOoriginalModelIdUpgraded.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-16"?>
 <OpenModel xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<Version>3.2.0</Version>
+	<Version>3.3.0</Version>
 	<OriginSettings>
 		<ProjectName>23070 -  HWP</ProjectName>
 		<ProjectDescription>23070_10000_0706_001</ProjectDescription>

--- a/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/OpenModel-SimpleUpgraded.xml
+++ b/src/IdeaStatiCa.IOM.VersioningServiceTests/TestData/OpenModel-SimpleUpgraded.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-16"?>
 <OpenModel xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Version>3.2.0</Version>
+  <Version>3.3.0</Version>
   <OriginSettings>
     <ProjectName>23070 -  HWP</ProjectName>
     <ProjectDescription>23070_10000_0706_001</ProjectDescription>


### PR DESCRIPTION
Persist the user's manual add/keep choice for connected members in Checkbot so it survives CAD/FEA re-import from the source model. Defaults to false (CAD-imported).

Add IOM 3.3.0 versioning step: upgrade is a no-op (missing element deserializes to default false); downgrade strips the property so pre-3.3.0 consumers don't encounter an unknown element.

Also return null from ConnectionPoint.Name so synthetic connection points fall back to the BimImporter `C {id}` label instead of inheriting coordinate-encoded node names from plugin links.

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
