### PR TITLE
Mark PlateElements.PlateType/PlateUID as [DataMember]

### DIFF
--- a/src/IdeaRS.OpenModel/Result/ResultOnMesh.cs
+++ b/src/IdeaRS.OpenModel/Result/ResultOnMesh.cs
@@ -122,10 +122,12 @@ namespace IdeaRS.OpenModel.Result
 		/// <summary>
 		/// Type plate elements
 		/// </summary>
+		[DataMember]
 		public StructuralPlateType PlateType { get; set;}
 		/// <summary>
 		/// Plate UID
 		/// </summary>
+		[DataMember]
 		public int PlateUID { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
ResultOnMesh / PlateElements are [DataContract] types, so Json.NET serializes them in opt-in mode. PlateType and PlateUID lacked [DataMember], so they were silently dropped from the serialized result mesh - losing which plate each element group belongs to and whether it is a steel plate or a weld. Required for exposing the FEM result mesh over the Connection REST API (GitHub discussion #1202).

Co-authored-by: Claude

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
