### PR TITLE
Add ParameterExpressionType to IdeaParameterUpdate

### DIFF
--- a/src/IdeaStatiCa.Api/Connection/Model/Parameter/IdeaParameter.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Parameter/IdeaParameter.cs
@@ -6,6 +6,8 @@
 		public string Key { get; set; }
 
 		public string Expression { get; set; }
+
+		public ParameterExpressionType ExpressionType { get; set; } = ParameterExpressionType.Value;
 	}
 
 	public class IdeaParameterValidation

--- a/src/IdeaStatiCa.Api/Connection/Model/Parameter/ParameterExpressionType.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Parameter/ParameterExpressionType.cs
@@ -1,0 +1,11 @@
+namespace IdeaStatiCa.Api.Connection.Model
+{
+	public enum ParameterExpressionType
+	{
+		Value,                 // default — current behavior (sets Value/Expression)
+		LowerBound,
+		UpperBound,
+		DefaultExpression,
+		ValidationExpression
+	}
+}


### PR DESCRIPTION
Introduce ParameterExpressionType enum and an optional ExpressionType property (default Value) on IdeaParameterUpdate so a parameter update can target Value/Expression, LowerBound, UpperBound, DefaultExpression, or ValidationExpression. The field is optional and defaults to Value, so existing {Key, Expression} payloads keep working unchanged.

