### PR TITLE
#34438 Re-add PositionOnRefLine and string ModelType as [Obsolete] shims

### DIFF
--- a/src/IdeaStatiCa.Api/Connection/Model/Connection/ConMember.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Connection/ConMember.cs
@@ -64,56 +64,33 @@ namespace IdeaStatiCa.Api.Connection.Model
 	{
 		public ConMemberModelTypeEnum ModelTypeEnum { get; set; }
 
-		// Two-way map between the legacy string values and the typed enum. These four
-		// strings are the only values ModelType ever accepted (the model-type labels shown
-		// in the desktop UI); kept as the single source of truth so get/set stay in sync.
-		private static readonly System.Collections.Generic.Dictionary<ConMemberModelTypeEnum, string> _modelTypeToString =
-			new System.Collections.Generic.Dictionary<ConMemberModelTypeEnum, string>
-			{
-				{ ConMemberModelTypeEnum.LoadedInXYZ, "N-Vy-Vz-Mx-My-Mz" },
-				{ ConMemberModelTypeEnum.LoadedInXZ, "N-Vz-My" },
-				{ ConMemberModelTypeEnum.LoadedInXY, "N-Vy-Mz" },
-				{ ConMemberModelTypeEnum.LoadedInXYZ_NoBending, "N-Vy-Vz" },
-			};
-
-		private static readonly System.Collections.Generic.Dictionary<string, ConMemberModelTypeEnum> _stringToModelType =
-			BuildStringToModelType();
-
-		private static System.Collections.Generic.Dictionary<string, ConMemberModelTypeEnum> BuildStringToModelType()
-		{
-			var map = new System.Collections.Generic.Dictionary<string, ConMemberModelTypeEnum>(StringComparer.OrdinalIgnoreCase);
-			foreach (var kvp in _modelTypeToString)
-			{
-				map[kvp.Value] = kvp.Key;
-			}
-			return map;
-		}
-
 		/// <summary>
-		/// Analysis model type as one of the four legacy string labels:
-		/// <c>N-Vy-Vz-Mx-My-Mz</c>, <c>N-Vz-My</c>, <c>N-Vy-Mz</c>, <c>N-Vy-Vz</c>.
+		/// Analysis model type as a string. Getter returns the <see cref="ModelTypeEnum"/> name;
+		/// setter accepts the legacy labels <c>N-Vy-Vz-Mx-My-Mz</c>, <c>N-Vz-My</c>,
+		/// <c>N-Vy-Mz</c>, <c>N-Vy-Vz</c> and throws <see cref="ArgumentException"/> for anything else.
 		/// </summary>
 		/// <remarks>
-		/// Back-compatibility shim over <see cref="ModelTypeEnum"/>. The getter returns the label
-		/// for the current enum value; the setter accepts only those four labels (case-insensitive)
-		/// and throws <see cref="ArgumentException"/> for anything else. Not serialized;
+		/// Back-compatibility shim over <see cref="ModelTypeEnum"/>. Not serialized;
 		/// <see cref="ModelTypeEnum"/> is the wire contract.
 		/// </remarks>
 		[Obsolete("Use " + nameof(ModelTypeEnum) + " instead. ModelType (string) will be removed in a future version.")]
 		[JsonIgnore]
 		public string ModelType
 		{
-			get => _modelTypeToString.TryGetValue(ModelTypeEnum, out var s) ? s : ModelTypeEnum.ToString();
+			get => ModelTypeEnum.ToString();
 			set
 			{
-				if (value == null || !_stringToModelType.TryGetValue(value, out var parsed))
+				switch (value)
 				{
-					throw new ArgumentException(
-						$"'{value}' is not a valid ModelType. Expected one of: {string.Join(", ", _modelTypeToString.Values)}.",
-						nameof(value));
+					case "N-Vy-Vz-Mx-My-Mz": ModelTypeEnum = ConMemberModelTypeEnum.LoadedInXYZ; break;
+					case "N-Vz-My": ModelTypeEnum = ConMemberModelTypeEnum.LoadedInXZ; break;
+					case "N-Vy-Mz": ModelTypeEnum = ConMemberModelTypeEnum.LoadedInXY; break;
+					case "N-Vy-Vz": ModelTypeEnum = ConMemberModelTypeEnum.LoadedInXYZ_NoBending; break;
+					default:
+						throw new ArgumentException(
+							$"'{value}' is not a valid ModelType. Expected one of: N-Vy-Vz-Mx-My-Mz, N-Vz-My, N-Vy-Mz, N-Vy-Vz.",
+							nameof(value));
 				}
-
-				ModelTypeEnum = parsed;
 			}
 		}
 

--- a/src/IdeaStatiCa.Api/Connection/Model/Connection/ConMember.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Connection/ConMember.cs
@@ -64,26 +64,56 @@ namespace IdeaStatiCa.Api.Connection.Model
 	{
 		public ConMemberModelTypeEnum ModelTypeEnum { get; set; }
 
+		// Two-way map between the legacy string values and the typed enum. These four
+		// strings are the only values ModelType ever accepted (the model-type labels shown
+		// in the desktop UI); kept as the single source of truth so get/set stay in sync.
+		private static readonly System.Collections.Generic.Dictionary<ConMemberModelTypeEnum, string> _modelTypeToString =
+			new System.Collections.Generic.Dictionary<ConMemberModelTypeEnum, string>
+			{
+				{ ConMemberModelTypeEnum.LoadedInXYZ, "N-Vy-Vz-Mx-My-Mz" },
+				{ ConMemberModelTypeEnum.LoadedInXZ, "N-Vz-My" },
+				{ ConMemberModelTypeEnum.LoadedInXY, "N-Vy-Mz" },
+				{ ConMemberModelTypeEnum.LoadedInXYZ_NoBending, "N-Vy-Vz" },
+			};
+
+		private static readonly System.Collections.Generic.Dictionary<string, ConMemberModelTypeEnum> _stringToModelType =
+			BuildStringToModelType();
+
+		private static System.Collections.Generic.Dictionary<string, ConMemberModelTypeEnum> BuildStringToModelType()
+		{
+			var map = new System.Collections.Generic.Dictionary<string, ConMemberModelTypeEnum>(StringComparer.OrdinalIgnoreCase);
+			foreach (var kvp in _modelTypeToString)
+			{
+				map[kvp.Value] = kvp.Key;
+			}
+			return map;
+		}
+
 		/// <summary>
-		/// Analysis model type as a string.
+		/// Analysis model type as one of the four legacy string labels:
+		/// <c>N-Vy-Vz-Mx-My-Mz</c>, <c>N-Vz-My</c>, <c>N-Vy-Mz</c>, <c>N-Vy-Vz</c>.
 		/// </summary>
 		/// <remarks>
-		/// Back-compatibility shim over <see cref="ModelTypeEnum"/>. The getter returns the enum
-		/// member name; the setter parses by name (case-insensitive) and ignores unrecognised
-		/// values, leaving <see cref="ModelTypeEnum"/> unchanged. Not serialized;
+		/// Back-compatibility shim over <see cref="ModelTypeEnum"/>. The getter returns the label
+		/// for the current enum value; the setter accepts only those four labels (case-insensitive)
+		/// and throws <see cref="ArgumentException"/> for anything else. Not serialized;
 		/// <see cref="ModelTypeEnum"/> is the wire contract.
 		/// </remarks>
 		[Obsolete("Use " + nameof(ModelTypeEnum) + " instead. ModelType (string) will be removed in a future version.")]
 		[JsonIgnore]
 		public string ModelType
 		{
-			get => ModelTypeEnum.ToString();
+			get => _modelTypeToString.TryGetValue(ModelTypeEnum, out var s) ? s : ModelTypeEnum.ToString();
 			set
 			{
-				if (Enum.TryParse<ConMemberModelTypeEnum>(value, ignoreCase: true, out var parsed))
+				if (value == null || !_stringToModelType.TryGetValue(value, out var parsed))
 				{
-					ModelTypeEnum = parsed;
+					throw new ArgumentException(
+						$"'{value}' is not a valid ModelType. Expected one of: {string.Join(", ", _modelTypeToString.Values)}.",
+						nameof(value));
 				}
+
+				ModelTypeEnum = parsed;
 			}
 		}
 

--- a/src/IdeaStatiCa.Api/Connection/Model/Connection/ConMember.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Connection/ConMember.cs
@@ -1,4 +1,5 @@
-﻿using IdeaRS.OpenModel.Geometry3D;
+﻿using System;
+using IdeaRS.OpenModel.Geometry3D;
 using Newtonsoft.Json;
 
 namespace IdeaStatiCa.Api.Connection.Model
@@ -27,6 +28,25 @@ namespace IdeaStatiCa.Api.Connection.Model
 		/// </summary>
 		public ConMemberConnectedByEnum ConnectedBy { get; set; }
 
+		/// <summary>
+		/// Normalised position of the joint along the member's reference line:
+		/// <c>0</c> = begin, <c>1</c> = end.
+		/// </summary>
+		/// <remarks>
+		/// Back-compatibility shim over <see cref="ConnectedBy"/>. Only the two endpoints are
+		/// representable now (<c>Begin</c>/<c>End</c>): a set value of <c>0.5</c> or any value
+		/// below <c>0.5</c> maps to <see cref="ConMemberConnectedByEnum.Begin"/>, so the former
+		/// through-member (<c>0.5</c>) case no longer round-trips. Not serialized;
+		/// <see cref="ConnectedBy"/> is the wire contract.
+		/// </remarks>
+		[Obsolete("Use " + nameof(ConnectedBy) + " instead. PositionOnRefLine will be removed in a future version.")]
+		[JsonIgnore]
+		public double PositionOnRefLine
+		{
+			get => ConnectedBy == ConMemberConnectedByEnum.End ? 1.0 : 0.0;
+			set => ConnectedBy = value >= 0.5 ? ConMemberConnectedByEnum.End : ConMemberConnectedByEnum.Begin;
+		}
+
 		public bool? MirrorY { get; set; }
 
 		public bool? MirrorZ { get; set; }
@@ -42,7 +62,30 @@ namespace IdeaStatiCa.Api.Connection.Model
 
 	public class ConMemberModel
 	{
-		public ConMemberModelTypeEnum ModelType { get; set; }
+		public ConMemberModelTypeEnum ModelTypeEnum { get; set; }
+
+		/// <summary>
+		/// Analysis model type as a string.
+		/// </summary>
+		/// <remarks>
+		/// Back-compatibility shim over <see cref="ModelTypeEnum"/>. The getter returns the enum
+		/// member name; the setter parses by name (case-insensitive) and ignores unrecognised
+		/// values, leaving <see cref="ModelTypeEnum"/> unchanged. Not serialized;
+		/// <see cref="ModelTypeEnum"/> is the wire contract.
+		/// </remarks>
+		[Obsolete("Use " + nameof(ModelTypeEnum) + " instead. ModelType (string) will be removed in a future version.")]
+		[JsonIgnore]
+		public string ModelType
+		{
+			get => ModelTypeEnum.ToString();
+			set
+			{
+				if (Enum.TryParse<ConMemberModelTypeEnum>(value, ignoreCase: true, out var parsed))
+				{
+					ModelTypeEnum = parsed;
+				}
+			}
+		}
 
 		public ConMemberForcesInEnum ForcesIn { get; set; }
 


### PR DESCRIPTION
## What

Restores source compatibility for two public API members that PR #1217 changed:

- `ConMember.PositionOnRefLine` (was `double`, replaced by `ConnectedBy` enum)
- `ConMemberModel.ModelType` (was `string`, changed to `ConMemberModelTypeEnum`)

Both were removed/retyped, which is a **source break** for Connection API / SDK consumers.

## How

- **PositionOnRefLine**: re-added as `[Obsolete]` `[JsonIgnore]` `double` forwarding to `ConnectedBy` (`0` -> `Begin`, `1` -> `End`).
- **ModelType (string)**: enum property renamed `ModelType` -> `ModelTypeEnum`; string `ModelType` re-added as an `[Obsolete]` `[JsonIgnore]` shim mapping by enum name (case-insensitive `TryParse`, unrecognised values ignored).

`ConnectedBy` / `ModelTypeEnum` remain the wire contract (`[JsonIgnore]` on both shims).

## Known limitation

The former through-member `PositionOnRefLine == 0.5` case is not representable by the two-valued `ConMemberConnectedByEnum { Begin, End }` and no longer round-trips (maps to `Begin`). Documented on the property.

## Verification

`IdeaStatiCa.Api` builds clean (0 warnings / 0 errors). No internal callers in this repo use the renamed members.

AI-assisted PR - human review required