### PR TITLE
#35300 Force manual conversion for unsupported CSS shape

### DIFF
--- a/src/bim-links/rstab/IdeaRstabPlugin/BimApi/RstabCrossSectionByName.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/BimApi/RstabCrossSectionByName.cs
@@ -1,0 +1,18 @@
+using IdeaStatiCa.BimApi;
+
+namespace IdeaRstabPlugin.BimApi
+{
+	/// <inheritdoc cref="IIdeaCrossSectionByName"/>
+	internal class RstabCrossSectionByName : IIdeaCrossSectionByName
+	{
+		public double Rotation { get; set; }
+
+		public string Id { get; set; }
+
+		public string Name { get; set; }
+
+		public IIdeaMaterial Material { get; set; }
+
+		public bool IsInPrincipal => false;
+	}
+}

--- a/src/bim-links/rstab/IdeaRstabPlugin/BimApi/RstabCrossSectionParametric.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/BimApi/RstabCrossSectionParametric.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 
 namespace IdeaRstabPlugin.BimApi
 {
-	/// <inheritdoc cref="IIdeaCrossSectionByName"/>
-	internal class RstabCrossSectionParametric : IIdeaCrossSectionByName
+	/// <inheritdoc cref="IIdeaCrossSectionByParameters"/>
+	internal class RstabCrossSectionParametric : IIdeaCrossSectionByParameters
 	{
 		public double Rotation { get; set; }
 

--- a/src/bim-links/rstab/IdeaRstabPlugin/Factories/CrossSectionFactory.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/Factories/CrossSectionFactory.cs
@@ -157,8 +157,9 @@ namespace IdeaRstabPlugin.Factories
 				case "CHS":
 					CssHelperFactory.FillCssCHS(crossSectionParameter, css);
 					break;
-
-				case "2I":
+                case "TO":
+					return CreateCssByName(cssData, objectFactory);					
+                case "2I":
 				case "2UR":
 				case "2UV":
 				case "2UK":
@@ -167,8 +168,7 @@ namespace IdeaRstabPlugin.Factories
 				case "2LB":
 				case "2L(B)":
 				case "2L(BA)":
-				case "2L(BB)":
-				case "TO":
+				case "2L(BB)":				
 				case "DICKQ":
 				default:
 					//if (!ResolveThinwalledCssShapeV3(crossSectionParameter, css))
@@ -181,7 +181,7 @@ namespace IdeaRstabPlugin.Factories
 						}
 					}
 					break;
-			}
+			}			
 
 			var cssParametric = new RstabCrossSectionParametric()
 			{
@@ -196,7 +196,18 @@ namespace IdeaRstabPlugin.Factories
 			return cssParametric;
 		}
 
-		private bool TryImportCssThinWalled(CrossSectionParameter crossSectionParameter, Dlubal.RSTAB8.ICrossSection css)
+		private RstabCrossSectionByName CreateCssByName(Dlubal.RSTAB8.CrossSection cssData, IObjectFactory objectFactory)
+		{
+			return new RstabCrossSectionByName()
+			{
+				Id = $"css-{cssData.No}",
+				Name = cssData.Description,
+				Material = objectFactory.GetMaterial(cssData.MaterialNo),
+				Rotation = 0,
+			};
+		}
+
+        private bool TryImportCssThinWalled(CrossSectionParameter crossSectionParameter, Dlubal.RSTAB8.ICrossSection css)
 		{
 			IrsCrossSectionDB2 cssDB = (IrsCrossSectionDB2)css.GetDatabaseCrossSection();
 			double type = cssDB.rsGetProperty((DB_CRSC_PROPERTY_ID)CssDbPropertyType);


### PR DESCRIPTION
We can not handle 'TO' shape cross-sections parametrically coming from old RSTAB 8. 
Issue is fixed by forcing the manual user conversion for this shape. 
