### PR TITLE
Fix: register IdentifierComparer in GetBimLink so hub/MC import match…

### DIFF
--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/BimApi/NegativePlate.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/BimApi/NegativePlate.cs
@@ -7,7 +7,6 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.BimApi
 		public NegativePlate(string no)
 			: base(no)
 		{
-			Name = $"NP{No}";
 		}
 	}
 }

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCaClient.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCaClient.cs
@@ -167,6 +167,7 @@ namespace IdeaStatiCa.TeklaStructuresPlugin
                     .WithImporters(x => x.RegisterContainer(new AutofacServiceProvider(container)))
                     .WithPluginHook(appVisibility)
                     .WithProgressMessaging(progressMessaging)
+                    .WithItemsComparer(new IdentifierComparer())
                     .WithUserDataSource(container.Resolve<UserDataSource>());
 
                 pluginLogger?.LogInformation("GetBimLink - Creating IApplicationBIM");


### PR DESCRIPTION
…es Checkbot

GetBimLink() (the hub / Model Coordinator entry point) omitted the .WithItemsComparer(new IdentifierComparer()) that Run() (Checkbot) sets. Without it, CadModelAdapter.ProcessConnectionObjects imports connection objects in raw Tekla order instead of plates-first. Anchor grids created before their base plate resolve ConnectedParts via a cache-only lookup that returns null, so AnchorGrid.ConnectedParts is emitted empty and base-plate references are dropped — producing anchors with no base plate in Model Coordinator.

Co-authored-by: Claude

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
