### PR TITLE
BimImporter CutImporter: self-number cut ids per connection, like plates

### DIFF
--- a/src/IdeaStatiCa.BimImporter/Importers/CutImporter.cs
+++ b/src/IdeaStatiCa.BimImporter/Importers/CutImporter.cs
@@ -34,6 +34,13 @@ namespace IdeaStatiCa.BimImporter.Importers
 				if (beamIOM is BeamData beam)
 				{
 					(beam.Cuts ?? (beam.Cuts = new List<CutData>())).Add(cutData);
+
+					//set correct Id - max across all beam cuts in the connection, same convention as plates
+					var maxCutId = (connectionData.Beams ?? Enumerable.Empty<BeamData>())
+						.Where(b => b.Cuts != null)
+						.SelectMany(b => b.Cuts)
+						.Max(c => (int?)c.Id) ?? 0;
+					cutData.Id = maxCutId + 1;
 				}
 
 				return cutData;
@@ -72,6 +79,9 @@ namespace IdeaStatiCa.BimImporter.Importers
 
 
 					(connectionData.CutBeamByBeams ?? (connectionData.CutBeamByBeams = new List<CutBeamByBeamData>())).Add(cutIOM);
+
+					//set correct Id - max existing in the connection, same convention as plates
+					cutIOM.Id = connectionData.CutBeamByBeams.Max(c => c.Id) + 1;
 
 					return cutIOM;
 				}


### PR DESCRIPTION
Imported cuts inherited Id from OpenElementId (CutData, CutBeamByBeamData) but CutImporter left them at 0, so every imported cut serialized with Id 0. Assign Max(existing)+1 within the connection - the same per-connection convention PlateImporter and WeldImporter already use (CutData numbered across all beams' cuts; CutBeamByBeamData across the connection list).

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
