### PR TITLE
BimImporter: don't drop the anchor-grid concrete block on import

### DIFF
--- a/src/IdeaStatiCa.BimImporter/Importers/ConnectionImporter.cs
+++ b/src/IdeaStatiCa.BimImporter/Importers/ConnectionImporter.cs
@@ -64,7 +64,9 @@ namespace IdeaStatiCa.BimImporter.Importers
 
 			if (connectionData.CutBeamByBeams == null) { connectionData.CutBeamByBeams = new List<CutBeamByBeamData>(); }
 
-			connectionData.ConcreteBlocks = new List<ConcreteBlockData>();
+			// Keep any ConcreteBlockData already added while importing the anchor grids (an anchor grid
+			// references its block by Id); only initialize when empty, like the other collections.
+			if (connectionData.ConcreteBlocks == null) { connectionData.ConcreteBlocks = new List<ConcreteBlockData>(); }
 
 			connection.PinGrids?.Where(e => e != null).ToList().ForEach(p => ctx.ImportConnectionItem(p, connectionData));
 


### PR DESCRIPTION
ConnectionImporter imported the anchor grids first - which, via AnchorGridImporter -> ConcreteBlockImporter, adds each referenced ConcreteBlockData to connectionData.ConcreteBlocks and points AnchorGrid.ConcreteBlock at it by Id. A few lines later ConcreteBlocks was then reassigned unconditionally to a fresh empty list, wiping those blocks and leaving the anchor grid with a dangling ConcreteBlock reference (Id present, no ConcreteBlockData in the model).

Guard the initialization like every other collection (only when null), preserving blocks added during anchor-grid import.

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
