### PR TITLE
#35699 Tekla: mirror Z for cold-formed C/EC sections

### DIFF
--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/CssFactoryHelper.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/CssFactoryHelper.cs
@@ -918,7 +918,7 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Utilities
 				lip = Math.Min(((double)cssProperties[EdgeFold1Key]).MilimetersToMeters(), ((double)cssProperties[EdgeFold2Key]).MilimetersToMeters());
 			}
 
-			CrossSectionFactory.FillColdFormedC(cssParameter, dWidth, dHeight, plateThickness, 0.1e-2, lip);
+			CrossSectionFactory.FillColdFormedC(cssParameter, dWidth, dHeight, plateThickness, 0.1e-2, lip, true);
 
 			return cssParameter;
 		}


### PR DESCRIPTION
Set mirrorZ on the CFC/EC cross-section (ConvertCCProfile) so the section definition carries the correct handedness for connections. Fixes CF section being mirrored when opened in Connection (e.g. MET-EB200E20+6).

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
