### PR TITLE
#35385: default ConItem.Active to true (GUI parity)

### DIFF
--- a/src/IdeaStatiCa.Api/Connection/Model/Connection/ConItem.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Connection/ConItem.cs
@@ -24,8 +24,10 @@
 		public string Name { get; set; }
 
 		/// <summary>
-		/// True if operation is active
+		/// True if the item is active. Defaults to true (GUI parity): the desktop always creates active
+		/// items, so a POST that omits <c>active</c> deserializes without touching this property and stays
+		/// active, instead of the bool default (false) that silently stored an inactive no-op (#35385).
 		/// </summary>
-		public bool Active { get; set; }
+		public bool Active { get; set; } = true;
 	}
 }


### PR DESCRIPTION
The desktop always creates active items; a REST POST that omits 'active' deserialized to the bool default (false), silently storing an inactive no-op (addedWithoutIssues:true, no geometry). Defaulting the property to true makes omit->active, while explicit true/false are preserved. Applies to ConItem and its subclasses (operations, members, load effects).

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
