### PR TITLE
#35688 CAD sync: resolve derived/un-tokenised entities without aborti…

### DIFF
--- a/src/IdeaStatiCa.BimApiLink/Plugin/ProjectAdapter.cs
+++ b/src/IdeaStatiCa.BimApiLink/Plugin/ProjectAdapter.cs
@@ -22,9 +22,22 @@ namespace IdeaStatiCa.BimApiLink.Plugin
 
 		public IIdeaObject GetBimObject(int id)
 		{
-			IIdeaObject obj = _bimApiImporter.Get(_project.GetIdentifier(id));
-
-			return obj;
+			// Return null for an id the link cannot resolve — one with no stored persistence token, or a token that is
+			// not an identifier. Callers (BimImporter.ImportGroup, CadApplication) filter nulls by design; the underlying
+			// GetIdentifier/GetPersistenceToken throw for such ids, which would otherwise abort the whole group and fail
+			// a Connections sync when a group carries a derived, un-tokenised entity (#35688).
+			try
+			{
+				return _bimApiImporter.Get(_project.GetIdentifier(id));
+			}
+			catch (KeyNotFoundException)
+			{
+				return null;
+			}
+			catch (ArgumentException)
+			{
+				return null;
+			}
 		}
 
 		public int GetIomId(string bimApiId)

--- a/src/IdeaStatiCa.BimImporter/Persistence/PersistenceTokenConverter.cs
+++ b/src/IdeaStatiCa.BimImporter/Persistence/PersistenceTokenConverter.cs
@@ -60,6 +60,14 @@ namespace IdeaStatiCa.BimImporter.Persistence
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
 		{
+			// A persistence token can legitimately be null (an entity that carries no native token — e.g. a
+			// PackedIdentity whose Token is null). Newtonsoft still invokes this converter for the null value, so
+			// return null instead of trying to load a JObject from a Null reader token (which throws).
+			if (reader.TokenType == JsonToken.Null)
+			{
+				return null;
+			}
+
 			// load the json object
 			JObject obj = JObject.Load(reader);
 

--- a/src/IdeaStatiCa.BimImporter/ProjectNoCache.cs
+++ b/src/IdeaStatiCa.BimImporter/ProjectNoCache.cs
@@ -166,6 +166,18 @@ namespace IdeaStatiCa.BimImporter
 		/// <inheritdoc cref="IBimIdMapAccess.ImportIdMap"/>
 		public void ImportIdMap(IEnumerable<(int IomId, string SourceIdToken)> entries)
 		{
+			// Idempotent: MC may re-seed a link that already imported this session. Such a link holds the mappings
+			// but, for derived connection nodes, not their persistence tokens (they are tokenised in a transient
+			// import scope, not the durable store the resolver reads). The re-seed then tops up those missing tokens.
+			// StoreMapping/StoreToken throw on duplicates, so skip entries already present instead of re-adding them
+			// (#35688 CAD sync); without this the re-seed could only run on a fresh, empty map.
+			HashSet<(int, string)> existingMappings = new HashSet<(int, string)>(_persistence.GetMappings());
+			HashSet<string> existingTokens = new HashSet<string>();
+			foreach ((string bimApiId, IIdeaPersistenceToken _) in _persistence.GetTokens())
+			{
+				existingTokens.Add(bimApiId);
+			}
+
 			foreach ((int iomId, string sourceIdToken) in entries)
 			{
 				PackedIdentity identity = JsonConvert.DeserializeObject<PackedIdentity>(sourceIdToken, SourceIdTokenSettings());
@@ -174,8 +186,11 @@ namespace IdeaStatiCa.BimImporter
 					continue;
 				}
 
-				_persistence.StoreMapping(iomId, identity.BimApiId);
-				if (identity.Token != null)
+				if (existingMappings.Add((iomId, identity.BimApiId)))
+				{
+					_persistence.StoreMapping(iomId, identity.BimApiId);
+				}
+				if (identity.Token != null && existingTokens.Add(identity.BimApiId))
 				{
 					_persistence.StoreToken(identity.BimApiId, identity.Token);
 				}

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Importers/AnchorGridImporter.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Importers/AnchorGridImporter.cs
@@ -37,7 +37,12 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Importers
 
 			PlugInLogger.LogInformation("Create - Found anchor with GUID: " + anchor2.Identifier.GUID);
 
-			var anchorGrid = new AnchorGrid(anchor2.Identifier.GUID.ToString())
+			// Identity must be the FULL received id (anchor GUID + ';'-appended concrete-block id, see IdentifierHelper),
+			// not just the anchor GUID — otherwise the persistence Token drops the concrete-block suffix and a CAD sync's
+			// CP-path re-resolution (ConnectionPoint token → AnchorGrids) rebuilds the anchor grid without its concrete
+			// block, losing the base-plate concrete + crashing the physical swap (#35688). The anchor lookup and the
+			// concrete-block loop below both re-split the id, so this does not affect the whole-model import.
+			var anchorGrid = new AnchorGrid(id)
 			{
 				BoltShearType = IdeaRS.OpenModel.Parameters.BoltShearType.Interaction,
 				ConnectedParts = new List<IIdeaObjectConnectable>(),


### PR DESCRIPTION
…ng the group

- ProjectAdapter.Get: return null (not throw) for an id with no/invalid persistence token
- PersistenceTokenConverter: read a null token as null instead of throwing on it
- ProjectNoCache re-seed: idempotent (skip mappings/tokens already present)
- AnchorGridImporter: keep the full id (anchor GUID + concrete-block suffix) so a CP-path re-resolution rebuilds the anchor grid with its concrete block

Co-authored-by: Claude

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
