### PR TITLE
#35544 Snap LCS based on angle tolerance

### DIFF
--- a/src/bim-links/rstab/IdeaRstabPlugin/Factories/ElementFactory.cs
+++ b/src/bim-links/rstab/IdeaRstabPlugin/Factories/ElementFactory.cs
@@ -15,7 +15,7 @@ namespace IdeaRstabPlugin.Factories
 {
 	internal class ElementFactory : IElementFactory
 	{
-		private const double Tolerance = 1e-5;
+		private const double Tolerance = 1e-6;
 
 		private static readonly IPluginLogger _logger = LoggerProvider.GetLogger("bim.rstab.factories");
 
@@ -120,37 +120,39 @@ namespace IdeaRstabPlugin.Factories
 
 		private CoordSystem GetMemberLCS(int startNodeNo, int endNodeNo)
 		{
-			bool flipZAxis = !_importSession.IsGCSOrientedUpwards;
-
 			UnitVector3D axisX = GetAxisX(startNodeNo, endNodeNo);
 
+			// #35544 RSTAB classifies member orientation against the coordinate planes with an angular
+			// tolerance; a horizontal direction component below sin(tolAngle) must not steer the
+			// LCS azimuth, otherwise a mm-scale nodal offset rotates the whole LCS of an
+			// almost-vertical member.
+			double snapTol = System.Math.Sqrt(2 * Tolerance);
+			double refX = System.Math.Abs(axisX.X) < snapTol ? 0.0 : axisX.X;
+			double refY = System.Math.Abs(axisX.Y) < snapTol ? 0.0 : axisX.Y;
+
 			UnitVector3D axisZ, axisY;
-			if (axisX.Z.AlmostEqual(1.0, Tolerance))
+			UnitVector3D axisXRef = axisX;
+			
+			// column behavior
+			if (refX == 0.0 && refY == 0.0)
 			{
-				axisZ = UnitVector3D.XAxis.Negate();
-			}
-			else if (axisX.Z.AlmostEqual(-1.0, Tolerance))
-			{
-				axisZ = UnitVector3D.XAxis;
+				axisZ = axisX.Z > 0 ? UnitVector3D.XAxis.Negate() : UnitVector3D.XAxis;
 			}
 			else
 			{
 				axisZ = UnitVector3D.ZAxis;
-			}
+				axisXRef = UnitVector3D.Create(refX, refY, axisX.Z);
+			}		
 
-			if (flipZAxis)
-			{
-				axisZ = axisZ.Negate();
-			}
-
+			axisY = axisZ.CrossProduct(axisXRef);
+			axisZ = axisX.CrossProduct(axisY);
 			axisY = axisZ.CrossProduct(axisX);
-			axisZ = axisX.CrossProduct(axisY);			
-			
+
 			return new CoordSystemByVector()
 			{
 				VecX = MNVector2Vector(axisX),
-				VecY = MNVector2Vector(axisY),
-				VecZ = MNVector2Vector(axisZ),
+				VecY = MNVector2Vector(axisY.Negate()),
+				VecZ = MNVector2Vector(axisZ.Negate()),
 			};
 		}
 


### PR DESCRIPTION
Issue with RSTAB LCS for nearly vertical members:
- revert changes from #1234 
- implement new logic, which applies snap based on the tolerance to plane first, and after that the LCS is constructed as usual
- implementation is built on the Dlubal's docs here: https://www.dlubal.com/en/support-and-learning/support/knowledge-base/001449