### PR TITLE
#35688 Tekla CAD re-sync: pick up components added after import

### DIFF
--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCa.TeklaStructuresPlugin.projitems
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCa.TeklaStructuresPlugin.projitems
@@ -52,6 +52,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UserData\ImportContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UserData\UserDataSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\BulkSelectionHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\ConnectionTokenReconciler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\CssFactoryHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IdentifierComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IdentifierHelper.cs" />

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Importers/ConnectionImporter.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Importers/ConnectionImporter.cs
@@ -1,7 +1,10 @@
-﻿using IdeaStatiCa.BimApi;
+using IdeaStatiCa.BimApi;
 using IdeaStatiCa.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApiLink.Importers;
+using IdeaStatiCa.Plugin;
 using IdeaStatiCa.TeklaStructuresPlugin.BimApi;
+using IdeaStatiCa.TeklaStructuresPlugin.Utils;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -11,14 +14,23 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Importers
 	{
 		protected IModelClient Model { get; }
 
-		public ConnectionImporter(IModelClient model)
+		protected IPluginLogger Logger { get; }
+
+		public ConnectionImporter(IModelClient model, IPluginLogger logger)
 			: base()
 		{
 			Model = model;
+			Logger = logger;
 		}
 
 		public override IIdeaConnectionPoint Create(ConnectionIdentifier<IIdeaConnectionPoint> id)
 		{
+			// CAD re-sync: the token is a frozen import-time snapshot, so components added in Tekla after the import are
+			// missing from it. Re-discover components connected to the joint's members and merge them back into the token
+			// before the ConnectionPoint is rebuilt. The structural member-set stays frozen (see ConnectionTokenReconciler),
+			// so this can never re-cluster joints the way the reverted whole-model re-discovery did.
+			RefreshData(id);
+
 			var connectionPoint = new ConnectionPoint(id.GetStringId().ToString())
 			{
 				Node = Get(id.Node as Identifier<IIdeaNode>),
@@ -39,6 +51,38 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Importers
 		{
 			var cachedOject = Model.GetCachedObject(id);
 			return cachedOject is IIdeaConnectionPoint ? cachedOject as IIdeaConnectionPoint : null;
+		}
+
+		/// <summary>
+		/// Re-discovers components connected to the joint's members (via near-joint welds/bolts) and merges the newly
+		/// added ones into the token. Best-effort: any failure falls back to the frozen token so a re-sync never breaks.
+		/// </summary>
+		private void RefreshData(ConnectionIdentifier<IIdeaConnectionPoint> id)
+		{
+			try
+			{
+				if (id?.ConnectedMembers == null || id.ConnectedMembers.Count == 0 || id.Node == null)
+				{
+					return;
+				}
+
+				var jointPoint = Model.GetPoint3D(id.Node.GetId().ToString());
+				if (jointPoint == null)
+				{
+					return;
+				}
+
+				var memberHandles = id.ConnectedMembers
+					.Select(m => m.GetId()?.ToString())
+					.Where(h => h != null);
+
+				List<IIdentifier> discovered = IdentifierHelper.GetConnectedIdentifiers(Model, memberHandles, jointPoint);
+				ConnectionTokenReconciler.Apply(id, discovered, Logger);
+			}
+			catch (Exception ex)
+			{
+				Logger?.LogWarning($"CAD re-sync re-discovery failed for '{id?.GetStringId()}'; using the frozen token.", ex);
+			}
 		}
 	}
 }

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/ConnectionTokenReconciler.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/ConnectionTokenReconciler.cs
@@ -1,0 +1,95 @@
+using IdeaStatiCa.BimApi;
+using IdeaStatiCa.BimApiLink.Identifiers;
+using IdeaStatiCa.Plugin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IdeaStatiCa.TeklaStructuresPlugin.Utils
+{
+	/// <summary>
+	/// Merges the live CAD re-discovery result into a connection's persisted identifier token during a re-sync.
+	/// The token is rebuilt from a frozen import-time snapshot (see <c>ConnectionImporter</c>), so a component added
+	/// in Tekla AFTER the import is missing from it; this adds the freshly discovered components back in.
+	/// </summary>
+	/// <remarks>
+	/// Policy is reliability-first, so the reverted whole-model re-discovery (which added structural members and
+	/// re-clustered joints) cannot recur:
+	/// <list type="bullet">
+	/// <item>non-member components found by discovery (plates incl. plate-stiffeners, bolt grids, welds, cuts, anchor
+	/// grids, folded plates) are ADDED if not already present (dedup by id);</item>
+	/// <item>the STRUCTURAL member-set is FROZEN: a newly discovered <see cref="ConnectedMemberIdentifier{T}"/> not
+	/// already in the token is NOT added (a member contributes joint-clustering endpoints) — it is logged as a topology
+	/// change so a full re-detect can pick it up manually;</item>
+	/// <item>existing token entries are never removed here (keep-if-live); a component deleted in Tekla drops out later
+	/// because <c>ConnectionImporter.Create</c> filters ids that no longer resolve.</item>
+	/// </list>
+	/// Append-only + dedup ⇒ idempotent: a re-sync with no model change leaves the token unchanged.
+	/// </remarks>
+	public static class ConnectionTokenReconciler
+	{
+		public static void Apply(ConnectionIdentifier<IIdeaConnectionPoint> id, IReadOnlyList<IIdentifier> discovered, IPluginLogger logger)
+		{
+			if (id is null || discovered is null || discovered.Count == 0)
+			{
+				return;
+			}
+
+			var frozenMembers = new HashSet<string>(
+				(id.ConnectedMembers ?? new List<ImmutableIdentifier<IIdeaConnectedMember>>())
+					.Select(m => m.GetId()?.ToString())
+					.Where(s => s != null),
+				StringComparer.OrdinalIgnoreCase);
+
+			foreach (IIdentifier item in discovered)
+			{
+				switch (item)
+				{
+					case ConnectedMemberIdentifier<IIdeaConnectedMember> member:
+						string memberId = member.GetId()?.ToString();
+						if (memberId != null && !frozenMembers.Contains(memberId))
+						{
+							logger?.LogInformation(
+								$"CAD re-sync: member '{memberId}' is connected at joint '{id.GetStringId()}' but was not part of the imported connection. " +
+								"The member-set is kept frozen to preserve connection detection/merge; run a full re-detect to include it.");
+						}
+
+						break;
+					case StringIdentifier<IIdeaPlate> plate:
+						AddIfNew(id.Plates, plate);
+						break;
+					case StringIdentifier<IIdeaBoltGrid> bolt:
+						AddIfNew(id.BoltGrids, bolt);
+						break;
+					case StringIdentifier<IIdeaWeld> weld:
+						AddIfNew(id.Welds, weld);
+						break;
+					case StringIdentifier<IIdeaCut> cut:
+						AddIfNew(id.Cuts, cut);
+						break;
+					case StringIdentifier<IIdeaAnchorGrid> anchor:
+						AddIfNew(id.AnchorGrids, anchor);
+						break;
+					case StringIdentifier<IIdeaFoldedPlate> folded:
+						AddIfNew(id.FoldedPlates, folded);
+						break;
+				}
+			}
+		}
+
+		private static void AddIfNew<T>(IList<ImmutableIdentifier<T>> collection, ImmutableIdentifier<T> item)
+			where T : IIdeaObject
+		{
+			if (collection is null)
+			{
+				return;
+			}
+
+			string newId = item.GetId()?.ToString();
+			if (!collection.Any(e => string.Equals(e.GetId()?.ToString(), newId, StringComparison.OrdinalIgnoreCase)))
+			{
+				collection.Add(item);
+			}
+		}
+	}
+}

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/IdentifierHelper.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/IdentifierHelper.cs
@@ -199,6 +199,137 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Utils
 			return identifiers;
 		}
 
+		/// <summary>
+		/// CAD re-sync discovery. From the joint's known member parts, follows near-joint welds and bolts to the sibling
+		/// parts they connect (an added stiffener plate is welded/bolted to a member, so it is reachable this way) and
+		/// classifies every reached object with <see cref="GetIdentifier"/>. Transitive (a plate welded to a plate welded
+		/// to a member is still reached) and bounded by the same near-joint proximity filter the per-member walk uses, so
+		/// it stays local to this joint. Seed members are walked with addToCollection:false — their own cuts/bolts/welds
+		/// are re-classified but the member itself is not re-added as a plate — mirroring the import member walk.
+		/// </summary>
+		internal static List<IIdentifier> GetConnectedIdentifiers(IModelClient model, IEnumerable<string> memberHandles, Point connectionPoint)
+		{
+			var identifiers = new List<IIdentifier>();
+			if (model == null || memberHandles == null || connectionPoint == null)
+			{
+				return identifiers;
+			}
+
+			var visited = new HashSet<string>();
+			var queue = new Queue<(Part part, bool isSeedMember)>();
+			foreach (string handle in memberHandles)
+			{
+				if (string.IsNullOrEmpty(handle) || !visited.Add(handle))
+				{
+					continue;
+				}
+
+				if (model.GetItemByHandler(handle) is Part memberPart)
+				{
+					queue.Enqueue((memberPart, true));
+				}
+			}
+
+			while (queue.Count > 0)
+			{
+				var (part, isSeedMember) = queue.Dequeue();
+
+				// Seed members: classify their own children only (addToCollection:false → the member is not re-added as a
+				// plate), like the import member walk. Discovered siblings: full classification (adds the stiffener plate).
+				identifiers = GetIdentifier(part, ref identifiers, !isSeedMember, connectionPoint);
+
+				foreach (Part sibling in GetConnectedSiblingParts(part, connectionPoint))
+				{
+					if (sibling != null && visited.Add(sibling.Identifier.GUID.ToString()))
+					{
+						queue.Enqueue((sibling, false));
+					}
+				}
+			}
+
+			return identifiers;
+		}
+
+		/// <summary>
+		/// Sibling parts connected to <paramref name="part"/> through its near-joint welds and bolts. Only welds/bolts
+		/// whose coordinate-system origin is near the connection (the same filter <see cref="GetIdentifier"/> applies to a
+		/// member's own welds/bolts) are followed, so the connectivity walk does not leak into a neighbouring joint.
+		/// </summary>
+		private static IEnumerable<Part> GetConnectedSiblingParts(Part part, Point connectionPoint)
+		{
+			var welds = part.GetWelds();
+			while (welds.MoveNext())
+			{
+				if (!(welds.Current is BaseWeld weld))
+				{
+					continue;
+				}
+
+				var origin = weld.GetCoordinateSystem()?.Origin as Point;
+				if (origin == null || !IsPointNearOfConnection(connectionPoint, part, origin))
+				{
+					continue;
+				}
+
+				if (weld.MainObject is Part main && !main.Identifier.Equals(part.Identifier))
+				{
+					yield return main;
+				}
+
+				if (weld.SecondaryObject is Part secondary && !secondary.Identifier.Equals(part.Identifier))
+				{
+					yield return secondary;
+				}
+			}
+
+			var bolts = part.GetBolts();
+			while (bolts.MoveNext())
+			{
+				if (!(bolts.Current is BoltGroup boltGroup))
+				{
+					continue;
+				}
+
+				var origin = boltGroup.GetCoordinateSystem()?.Origin as Point;
+				if (origin == null || !IsPointNearOfConnection(connectionPoint, part, origin))
+				{
+					continue;
+				}
+
+				foreach (Part boltedPart in ConnectedBoltParts(boltGroup))
+				{
+					if (!boltedPart.Identifier.Equals(part.Identifier))
+					{
+						yield return boltedPart;
+					}
+				}
+			}
+		}
+
+		private static IEnumerable<Part> ConnectedBoltParts(BoltGroup boltGroup)
+		{
+			if (boltGroup.PartToBoltTo is Part boltTo)
+			{
+				yield return boltTo;
+			}
+
+			if (boltGroup.PartToBeBolted is Part beBolted)
+			{
+				yield return beBolted;
+			}
+
+			if (boltGroup.OtherPartsToBolt != null)
+			{
+				foreach (var other in boltGroup.OtherPartsToBolt)
+				{
+					if (other is Part otherPart)
+					{
+						yield return otherPart;
+					}
+				}
+			}
+		}
+
 		private static void AddConcreteBlockToAnchor(List<IIdentifier> identifiers)
 		{
 			var concreteBlock = identifiers.Find(id => id is StringIdentifier<IIdeaConcreteBlock>) as StringIdentifier<IIdeaConcreteBlock>;

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresTest/ConnectionTokenReconcilerTest.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresTest/ConnectionTokenReconcilerTest.cs
@@ -1,0 +1,203 @@
+using FluentAssertions;
+using IdeaStatiCa.BimApi;
+using IdeaStatiCa.BimApiLink.Identifiers;
+using IdeaStatiCa.Plugin;
+using IdeaStatiCa.TeklaStructuresPlugin.Utils;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IdeaStatiCa.TeklaStructuresTest
+{
+	/// <summary>
+	/// Pure tests for the CAD re-sync token reconcile (the reliability-critical part of the added-element re-discovery).
+	/// The Tekla-touching connectivity walk (<c>IdentifierHelper.GetConnectedIdentifiers</c>) needs a live model and is
+	/// verified manually; here we feed a synthetic "discovered" list and assert how the token is merged.
+	/// </summary>
+	public class ConnectionTokenReconcilerTest
+	{
+		private static ConnectionIdentifier<IIdeaConnectionPoint> MakeToken(
+			IEnumerable<string> members = null,
+			IEnumerable<string> plates = null,
+			IEnumerable<string> welds = null)
+		{
+			var id = new ConnectionIdentifier<IIdeaConnectionPoint>(0, 0, 0)
+			{
+				ConnectedMembers = new List<ImmutableIdentifier<IIdeaConnectedMember>>(),
+				Plates = new List<ImmutableIdentifier<IIdeaPlate>>(),
+				BoltGrids = new List<ImmutableIdentifier<IIdeaBoltGrid>>(),
+				AnchorGrids = new List<ImmutableIdentifier<IIdeaAnchorGrid>>(),
+				Welds = new List<ImmutableIdentifier<IIdeaWeld>>(),
+				Cuts = new List<ImmutableIdentifier<IIdeaCut>>(),
+				FoldedPlates = new List<ImmutableIdentifier<IIdeaFoldedPlate>>(),
+			};
+
+			foreach (string m in members ?? Enumerable.Empty<string>())
+			{
+				id.ConnectedMembers.Add(new ConnectedMemberIdentifier<IIdeaConnectedMember>(m));
+			}
+
+			foreach (string p in plates ?? Enumerable.Empty<string>())
+			{
+				id.Plates.Add(new StringIdentifier<IIdeaPlate>(p));
+			}
+
+			foreach (string w in welds ?? Enumerable.Empty<string>())
+			{
+				id.Welds.Add(new StringIdentifier<IIdeaWeld>(w));
+			}
+
+			return id;
+		}
+
+		private static IReadOnlyList<string> Ids<T>(IEnumerable<ImmutableIdentifier<T>> collection)
+			where T : IIdeaObject
+			=> collection.Select(x => x.GetId().ToString()).ToList();
+
+		// 1. The user's case: a stiffener plate added in Tekla and surfaced by discovery is merged into the token.
+		[Test]
+		public void Apply_addsNewlyDiscoveredPlate()
+		{
+			var id = MakeToken(members: new[] { "M1" });
+			var discovered = new List<IIdentifier> { new StringIdentifier<IIdeaPlate>("P1") };
+
+			ConnectionTokenReconciler.Apply(id, discovered, Substitute.For<IPluginLogger>());
+
+			Ids(id.Plates).Should().ContainSingle().Which.Should().Be("P1");
+		}
+
+		// 2. A discovered component already in the token is not duplicated.
+		[Test]
+		public void Apply_doesNotDuplicateExistingComponent()
+		{
+			var id = MakeToken(members: new[] { "M1" }, plates: new[] { "P1" });
+			var discovered = new List<IIdentifier> { new StringIdentifier<IIdeaPlate>("P1") };
+
+			ConnectionTokenReconciler.Apply(id, discovered, Substitute.For<IPluginLogger>());
+
+			Ids(id.Plates).Should().Equal("P1");
+		}
+
+		// 3. The same component discovered twice (e.g. reached from two members) yields a single entry.
+		[Test]
+		public void Apply_dedupsSameComponentDiscoveredTwice()
+		{
+			var id = MakeToken(members: new[] { "M1" });
+			var discovered = new List<IIdentifier>
+			{
+				new StringIdentifier<IIdeaPlate>("P1"),
+				new StringIdentifier<IIdeaPlate>("P1"),
+			};
+
+			ConnectionTokenReconciler.Apply(id, discovered, Substitute.For<IPluginLogger>());
+
+			Ids(id.Plates).Should().Equal("P1");
+		}
+
+		// 4. Keep-if-live: an existing component that discovery does not re-surface is NOT dropped (miss-drop regression).
+		[Test]
+		public void Apply_keepsExistingComponentNotRediscovered()
+		{
+			var id = MakeToken(members: new[] { "M1" }, plates: new[] { "P1" });
+			var discovered = new List<IIdentifier> { new StringIdentifier<IIdeaPlate>("P2") };
+
+			ConnectionTokenReconciler.Apply(id, discovered, Substitute.For<IPluginLogger>());
+
+			Ids(id.Plates).Should().BeEquivalentTo("P1", "P2");
+		}
+
+		// 5. Structural member-set is frozen: a newly connected member is NOT added, and it is logged as a topology change.
+		[Test]
+		public void Apply_freezesNewStructuralMemberAndLogsIt()
+		{
+			var id = MakeToken(members: new[] { "M1" });
+			var logger = Substitute.For<IPluginLogger>();
+			var discovered = new List<IIdentifier> { new ConnectedMemberIdentifier<IIdeaConnectedMember>("M2") };
+
+			ConnectionTokenReconciler.Apply(id, discovered, logger);
+
+			Ids(id.ConnectedMembers).Should().Equal("M1");
+			logger.Received(1).LogInformation(Arg.Is<string>(s => s.Contains("M2")), Arg.Any<Exception>());
+		}
+
+		// 6. A frozen member re-surfaced by discovery is a no-op (no duplicate, no topology log).
+		[Test]
+		public void Apply_ignoresRediscoveredExistingMember()
+		{
+			var id = MakeToken(members: new[] { "M1" });
+			var logger = Substitute.For<IPluginLogger>();
+			var discovered = new List<IIdentifier> { new ConnectedMemberIdentifier<IIdeaConnectedMember>("M1") };
+
+			ConnectionTokenReconciler.Apply(id, discovered, logger);
+
+			Ids(id.ConnectedMembers).Should().Equal("M1");
+			logger.DidNotReceive().LogInformation(Arg.Any<string>(), Arg.Any<Exception>());
+		}
+
+		// 7. Each non-member kind lands in its own token collection.
+		[Test]
+		public void Apply_routesEachComponentKindToItsCollection()
+		{
+			var id = MakeToken(members: new[] { "M1" });
+			var discovered = new List<IIdentifier>
+			{
+				new StringIdentifier<IIdeaPlate>("P1"),
+				new StringIdentifier<IIdeaBoltGrid>("B1"),
+				new StringIdentifier<IIdeaWeld>("W1"),
+				new StringIdentifier<IIdeaCut>("C1"),
+				new StringIdentifier<IIdeaAnchorGrid>("A1"),
+				new StringIdentifier<IIdeaFoldedPlate>("F1"),
+			};
+
+			ConnectionTokenReconciler.Apply(id, discovered, Substitute.For<IPluginLogger>());
+
+			Ids(id.Plates).Should().Equal("P1");
+			Ids(id.BoltGrids).Should().Equal("B1");
+			Ids(id.Welds).Should().Equal("W1");
+			Ids(id.Cuts).Should().Equal("C1");
+			Ids(id.AnchorGrids).Should().Equal("A1");
+			Ids(id.FoldedPlates).Should().Equal("F1");
+		}
+
+		// 8. Idempotent: re-applying the same discovery result does not churn or duplicate.
+		[Test]
+		public void Apply_isIdempotent()
+		{
+			var id = MakeToken(members: new[] { "M1" });
+			var discovered = new List<IIdentifier> { new StringIdentifier<IIdeaPlate>("P1") };
+
+			ConnectionTokenReconciler.Apply(id, discovered, Substitute.For<IPluginLogger>());
+			ConnectionTokenReconciler.Apply(id, discovered, Substitute.For<IPluginLogger>());
+
+			Ids(id.Plates).Should().Equal("P1");
+		}
+
+		// 9. Degenerate inputs: empty / null discovery is a no-op and never throws.
+		[Test]
+		public void Apply_withEmptyOrNullDiscovery_isNoOp()
+		{
+			var id = MakeToken(members: new[] { "M1" }, plates: new[] { "P1" });
+
+			ConnectionTokenReconciler.Apply(id, new List<IIdentifier>(), Substitute.For<IPluginLogger>());
+			ConnectionTokenReconciler.Apply(id, null, Substitute.For<IPluginLogger>());
+
+			Ids(id.Plates).Should().Equal("P1");
+			Ids(id.ConnectedMembers).Should().Equal("M1");
+		}
+
+		// 10. A null logger is tolerated even when a topology change would be logged.
+		[Test]
+		public void Apply_withNullLogger_doesNotThrowOnNewMember()
+		{
+			var id = MakeToken(members: new[] { "M1" });
+			var discovered = new List<IIdentifier> { new ConnectedMemberIdentifier<IIdeaConnectedMember>("M2") };
+
+			Action act = () => ConnectionTokenReconciler.Apply(id, discovered, null);
+
+			act.Should().NotThrow();
+			Ids(id.ConnectedMembers).Should().Equal("M1");
+		}
+	}
+}


### PR DESCRIPTION
Sync rebuilds each connection from a frozen import-time token, so a component added in Tekla after the import (e.g. a second stiffener on a column) was never re-imported. ConnectionImporter.RefreshData now re-discovers components connected to the joint's members through near-joint welds/bolts (BaseWeld MainObject/ SecondaryObject, BoltGroup PartToBolt*), transitive and bounded by the existing member-relative proximity filter, classifies them with IdentifierHelper, and merges the new ones into the token (ConnectionTokenReconciler).

The structural member-set stays frozen: a newly discovered member is logged as a topology change, never added, so this can never re-cluster joints the way the reverted whole-model re-discovery did. Plate-stiffeners are picked up (they classify as plates). Append-only + dedup keeps it idempotent; a component deleted in Tekla still drops out via Create's existing null-filter.

Co-authored-by: Claude

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
