### PR TITLE
#35764 Correct the CheckResWeld.IsFullStrength documentation

### DIFF
--- a/src/IdeaRS.OpenModel/Connection/ConnectionCheckRes.cs
+++ b/src/IdeaRS.OpenModel/Connection/ConnectionCheckRes.cs
@@ -340,7 +340,7 @@ namespace IdeaRS.OpenModel.Connection
 
 		/// <summary>
 		/// Unity Check Stress. NaN when the weld has no computed stress utilisation,
-		/// see <see cref="IsNotStressRated"/>
+		/// see <see cref="IsFullStrength"/>
 		/// </summary>
 		[DataMember]
 		public double UnityCheck { get; set; }
@@ -354,12 +354,12 @@ namespace IdeaRS.OpenModel.Connection
 		/// <summary>
 		/// True when the check does not rate this weld by a stress utilisation, so its check is
 		/// satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed
-		/// edge-to-edge - note the latter includes fillet welds, which are not full strength, so
-		/// this flag is not a statement about the weld developing the capacity of the connected
-		/// plates. <see cref="UnityCheck"/> is NaN and <see cref="CheckStatus"/> is true in that case
+		/// edge-to-edge - despite the name, the latter includes fillet welds, so this flag is not a
+		/// statement that the weld develops the capacity of the connected plates. <see cref="UnityCheck"/>
+		/// is NaN and <see cref="CheckStatus"/> is true in that case
 		/// </summary>
 		[DataMember]
-		public bool IsNotStressRated { get; set; }
+		public bool IsFullStrength { get; set; }
 
 		/// <summary>
 		/// Id of Load Case

--- a/src/IdeaRS.OpenModel/Connection/ConnectionCheckRes.cs
+++ b/src/IdeaRS.OpenModel/Connection/ConnectionCheckRes.cs
@@ -339,8 +339,8 @@ namespace IdeaRS.OpenModel.Connection
 		public int Id { get; set; }
 
 		/// <summary>
-		/// Unity Check Stress. NaN when the weld has no computed stress utilisation -
-		/// full-strength welds are not stress-checked, see <see cref="IsFullStrength"/>
+		/// Unity Check Stress. NaN when the weld has no computed stress utilisation,
+		/// see <see cref="IsNotStressRated"/>
 		/// </summary>
 		[DataMember]
 		public double UnityCheck { get; set; }
@@ -352,13 +352,14 @@ namespace IdeaRS.OpenModel.Connection
 		public bool CheckStatus { get; set; }
 
 		/// <summary>
-		/// True when the weld is not rated by a stress utilisation and its check is satisfied by definition -
-		/// the check treats it as a full-strength weld. This applies to butt/bevel welds (e.g. CJP) and to
-		/// welds placed edge-to-edge. <see cref="UnityCheck"/> is NaN and <see cref="CheckStatus"/> is true
-		/// in that case
+		/// True when the check does not rate this weld by a stress utilisation, so its check is
+		/// satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed
+		/// edge-to-edge - note the latter includes fillet welds, which are not full strength, so
+		/// this flag is not a statement about the weld developing the capacity of the connected
+		/// plates. <see cref="UnityCheck"/> is NaN and <see cref="CheckStatus"/> is true in that case
 		/// </summary>
 		[DataMember]
-		public bool IsFullStrength { get; set; }
+		public bool IsNotStressRated { get; set; }
 
 		/// <summary>
 		/// Id of Load Case

--- a/src/api-sdks/connection-api/clients/csharp/api/openapi.yaml
+++ b/src/api-sdks/connection-api/clients/csharp/api/openapi.yaml
@@ -6158,7 +6158,7 @@ components:
         name: name
         id: 5
         loadCaseId: 7
-        isNotStressRated: true
+        isFullStrength: true
         items:
         - 9
         - 9
@@ -6172,14 +6172,14 @@ components:
           format: int32
           type: integer
         unityCheck:
-          description: "Unity Check Stress. NaN when the weld has no computed stress utilisation,\r\nsee IdeaRS.OpenModel.Connection.CheckResWeld.IsNotStressRated"
+          description: "Unity Check Stress. NaN when the weld has no computed stress utilisation,\r\nsee IdeaRS.OpenModel.Connection.CheckResWeld.IsFullStrength"
           format: double
           type: number
         checkStatus:
           description: Status of the Check
           type: boolean
-        isNotStressRated:
-          description: "True when the check does not rate this weld by a stress utilisation, so its check is\r\nsatisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed\r\nedge-to-edge - note the latter includes fillet welds, which are not full strength, so\r\nthis flag is not a statement about the weld developing the capacity of the connected\r\nplates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case"
+        isFullStrength:
+          description: "True when the check does not rate this weld by a stress utilisation, so its check is\r\nsatisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed\r\nedge-to-edge - despite the name, the latter includes fillet welds, so this flag is not a\r\nstatement that the weld develops the capacity of the connected plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case"
           type: boolean
         loadCaseId:
           description: Id of Load Case
@@ -7368,7 +7368,7 @@ components:
           name: name
           id: 5
           loadCaseId: 7
-          isNotStressRated: true
+          isFullStrength: true
           items:
           - 9
           - 9
@@ -7377,7 +7377,7 @@ components:
           name: name
           id: 5
           loadCaseId: 7
-          isNotStressRated: true
+          isFullStrength: true
           items:
           - 9
           - 9

--- a/src/api-sdks/connection-api/clients/csharp/api/openapi.yaml
+++ b/src/api-sdks/connection-api/clients/csharp/api/openapi.yaml
@@ -6158,7 +6158,7 @@ components:
         name: name
         id: 5
         loadCaseId: 7
-        isFullStrength: true
+        isNotStressRated: true
         items:
         - 9
         - 9
@@ -6172,20 +6172,14 @@ components:
           format: int32
           type: integer
         unityCheck:
-          description: "Unity Check Stress. NaN when the weld has no computed stress\
-            \ utilisation -\r\nfull-strength welds are not stress-checked, see IdeaRS.OpenModel.Connection.CheckResWeld.IsFullStrength"
+          description: "Unity Check Stress. NaN when the weld has no computed stress utilisation,\r\nsee IdeaRS.OpenModel.Connection.CheckResWeld.IsNotStressRated"
           format: double
           type: number
         checkStatus:
           description: Status of the Check
           type: boolean
-        isFullStrength:
-          description: "True when the weld is not rated by a stress utilisation and\
-            \ its check is satisfied by definition -\r\nthe check treats it as a full-strength\
-            \ weld. This applies to butt/bevel welds (e.g. CJP) and to\r\nwelds placed\
-            \ edge-to-edge. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is\
-            \ NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true\r\
-            \nin that case"
+        isNotStressRated:
+          description: "True when the check does not rate this weld by a stress utilisation, so its check is\r\nsatisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed\r\nedge-to-edge - note the latter includes fillet welds, which are not full strength, so\r\nthis flag is not a statement about the weld developing the capacity of the connected\r\nplates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case"
           type: boolean
         loadCaseId:
           description: Id of Load Case
@@ -7374,7 +7368,7 @@ components:
           name: name
           id: 5
           loadCaseId: 7
-          isFullStrength: true
+          isNotStressRated: true
           items:
           - 9
           - 9
@@ -7383,7 +7377,7 @@ components:
           name: name
           id: 5
           loadCaseId: 7
-          isFullStrength: true
+          isNotStressRated: true
           items:
           - 9
           - 9

--- a/src/api-sdks/connection-api/clients/csharp/docs/CheckResWeld.md
+++ b/src/api-sdks/connection-api/clients/csharp/docs/CheckResWeld.md
@@ -7,9 +7,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** | Name of Weld | [optional] 
 **Id** | **int** | Unique id of weld | [optional] 
-**UnityCheck** | **double** | Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsNotStressRated | [optional] 
+**UnityCheck** | **double** | Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsFullStrength | [optional] 
 **CheckStatus** | **bool** | Status of the Check | [optional] 
-**IsNotStressRated** | **bool** | True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - note the latter includes fillet welds, which are not full strength, so  this flag is not a statement about the weld developing the capacity of the connected  plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case | [optional] 
+**IsFullStrength** | **bool** | True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - despite the name, the latter includes fillet welds, so this flag is not a  statement that the weld develops the capacity of the connected plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case | [optional] 
 **LoadCaseId** | **int** | Id of Load Case | [optional] 
 **Items** | **List&lt;int&gt;** | In case of presentation of groups plates (uncoiled beams) | [optional] 
 

--- a/src/api-sdks/connection-api/clients/csharp/docs/CheckResWeld.md
+++ b/src/api-sdks/connection-api/clients/csharp/docs/CheckResWeld.md
@@ -7,9 +7,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** | Name of Weld | [optional] 
 **Id** | **int** | Unique id of weld | [optional] 
-**UnityCheck** | **double** | Unity Check Stress. NaN when the weld has no computed stress utilisation -  full-strength welds are not stress-checked, see IdeaRS.OpenModel.Connection.CheckResWeld.IsFullStrength | [optional] 
+**UnityCheck** | **double** | Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsNotStressRated | [optional] 
 **CheckStatus** | **bool** | Status of the Check | [optional] 
-**IsFullStrength** | **bool** | True when the weld is not rated by a stress utilisation and its check is satisfied by definition -  the check treats it as a full-strength weld. This applies to butt/bevel welds (e.g. CJP) and to  welds placed edge-to-edge. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true  in that case | [optional] 
+**IsNotStressRated** | **bool** | True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - note the latter includes fillet welds, which are not full strength, so  this flag is not a statement about the weld developing the capacity of the connected  plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case | [optional] 
 **LoadCaseId** | **int** | Id of Load Case | [optional] 
 **Items** | **List&lt;int&gt;** | In case of presentation of groups plates (uncoiled beams) | [optional] 
 

--- a/src/api-sdks/connection-api/clients/python/docs/CheckResWeld.md
+++ b/src/api-sdks/connection-api/clients/python/docs/CheckResWeld.md
@@ -8,9 +8,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | Name of Weld | [optional] 
 **id** | **int** | Unique id of weld | [optional] 
-**unity_check** | **float** | Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsNotStressRated | [optional] 
+**unity_check** | **float** | Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsFullStrength | [optional] 
 **check_status** | **bool** | Status of the Check | [optional] 
-**is_not_stress_rated** | **bool** | True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - note the latter includes fillet welds, which are not full strength, so  this flag is not a statement about the weld developing the capacity of the connected  plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case | [optional] 
+**is_full_strength** | **bool** | True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - despite the name, the latter includes fillet welds, so this flag is not a  statement that the weld develops the capacity of the connected plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case | [optional] 
 **load_case_id** | **int** | Id of Load Case | [optional] 
 **items** | **List[int]** | In case of presentation of groups plates (uncoiled beams) | [optional] 
 

--- a/src/api-sdks/connection-api/clients/python/docs/CheckResWeld.md
+++ b/src/api-sdks/connection-api/clients/python/docs/CheckResWeld.md
@@ -8,9 +8,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | Name of Weld | [optional] 
 **id** | **int** | Unique id of weld | [optional] 
-**unity_check** | **float** | Unity Check Stress. NaN when the weld has no computed stress utilisation -  full-strength welds are not stress-checked, see IdeaRS.OpenModel.Connection.CheckResWeld.IsFullStrength | [optional] 
+**unity_check** | **float** | Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsNotStressRated | [optional] 
 **check_status** | **bool** | Status of the Check | [optional] 
-**is_full_strength** | **bool** | True when the weld is not rated by a stress utilisation and its check is satisfied by definition -  the check treats it as a full-strength weld. This applies to butt/bevel welds (e.g. CJP) and to  welds placed edge-to-edge. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true  in that case | [optional] 
+**is_not_stress_rated** | **bool** | True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - note the latter includes fillet welds, which are not full strength, so  this flag is not a statement about the weld developing the capacity of the connected  plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case | [optional] 
 **load_case_id** | **int** | Id of Load Case | [optional] 
 **items** | **List[int]** | In case of presentation of groups plates (uncoiled beams) | [optional] 
 

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/models/check_res_weld.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/models/check_res_weld.py
@@ -29,12 +29,12 @@ class CheckResWeld(BaseModel):
     """ # noqa: E501
     name: Optional[StrictStr] = Field(default=None, description="Name of Weld")
     id: Optional[StrictInt] = Field(default=None, description="Unique id of weld")
-    unity_check: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Unity Check Stress. NaN when the weld has no computed stress utilisation -  full-strength welds are not stress-checked, see IdeaRS.OpenModel.Connection.CheckResWeld.IsFullStrength", alias="unityCheck")
+    unity_check: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsNotStressRated", alias="unityCheck")
     check_status: Optional[StrictBool] = Field(default=None, description="Status of the Check", alias="checkStatus")
-    is_full_strength: Optional[StrictBool] = Field(default=None, description="True when the weld is not rated by a stress utilisation and its check is satisfied by definition -  the check treats it as a full-strength weld. This applies to butt/bevel welds (e.g. CJP) and to  welds placed edge-to-edge. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true  in that case", alias="isFullStrength")
+    is_not_stress_rated: Optional[StrictBool] = Field(default=None, description="True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - note the latter includes fillet welds, which are not full strength, so  this flag is not a statement about the weld developing the capacity of the connected  plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case", alias="isNotStressRated")
     load_case_id: Optional[StrictInt] = Field(default=None, description="Id of Load Case", alias="loadCaseId")
     items: Optional[List[StrictInt]] = Field(default=None, description="In case of presentation of groups plates (uncoiled beams)")
-    __properties: ClassVar[List[str]] = ["name", "id", "unityCheck", "checkStatus", "isFullStrength", "loadCaseId", "items"]
+    __properties: ClassVar[List[str]] = ["name", "id", "unityCheck", "checkStatus", "isNotStressRated", "loadCaseId", "items"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,7 +101,7 @@ class CheckResWeld(BaseModel):
             "id": obj.get("id"),
             "unityCheck": obj.get("unityCheck"),
             "checkStatus": obj.get("checkStatus"),
-            "isFullStrength": obj.get("isFullStrength"),
+            "isNotStressRated": obj.get("isNotStressRated"),
             "loadCaseId": obj.get("loadCaseId"),
             "items": obj.get("items")
         })

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/models/check_res_weld.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/models/check_res_weld.py
@@ -29,12 +29,12 @@ class CheckResWeld(BaseModel):
     """ # noqa: E501
     name: Optional[StrictStr] = Field(default=None, description="Name of Weld")
     id: Optional[StrictInt] = Field(default=None, description="Unique id of weld")
-    unity_check: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsNotStressRated", alias="unityCheck")
+    unity_check: Optional[Union[StrictFloat, StrictInt]] = Field(default=None, description="Unity Check Stress. NaN when the weld has no computed stress utilisation,  see IdeaRS.OpenModel.Connection.CheckResWeld.IsFullStrength", alias="unityCheck")
     check_status: Optional[StrictBool] = Field(default=None, description="Status of the Check", alias="checkStatus")
-    is_not_stress_rated: Optional[StrictBool] = Field(default=None, description="True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - note the latter includes fillet welds, which are not full strength, so  this flag is not a statement about the weld developing the capacity of the connected  plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case", alias="isNotStressRated")
+    is_full_strength: Optional[StrictBool] = Field(default=None, description="True when the check does not rate this weld by a stress utilisation, so its check is  satisfied by definition. Set for butt/bevel welds (e.g. CJP) and for any weld placed  edge-to-edge - despite the name, the latter includes fillet welds, so this flag is not a  statement that the weld develops the capacity of the connected plates. IdeaRS.OpenModel.Connection.CheckResWeld.UnityCheck is NaN and IdeaRS.OpenModel.Connection.CheckResWeld.CheckStatus is true in that case", alias="isFullStrength")
     load_case_id: Optional[StrictInt] = Field(default=None, description="Id of Load Case", alias="loadCaseId")
     items: Optional[List[StrictInt]] = Field(default=None, description="In case of presentation of groups plates (uncoiled beams)")
-    __properties: ClassVar[List[str]] = ["name", "id", "unityCheck", "checkStatus", "isNotStressRated", "loadCaseId", "items"]
+    __properties: ClassVar[List[str]] = ["name", "id", "unityCheck", "checkStatus", "isFullStrength", "loadCaseId", "items"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -101,7 +101,7 @@ class CheckResWeld(BaseModel):
             "id": obj.get("id"),
             "unityCheck": obj.get("unityCheck"),
             "checkStatus": obj.get("checkStatus"),
-            "isNotStressRated": obj.get("isNotStressRated"),
+            "isFullStrength": obj.get("isFullStrength"),
             "loadCaseId": obj.get("loadCaseId"),
             "items": obj.get("items")
         })


### PR DESCRIPTION
Documentation only. Acts on review feedback on ADO PR 27601 (thread 203747), but **keeps the published property name** - an earlier revision of this branch renamed it, and that was dropped deliberately.

## Why
`CheckResWeld.IsFullStrength` mirrors the engine's `IsButtWeld` marker, and `CalculatorUtil.SetButtWelds` (CalculatorUtil.cs:891) sets that for:

```csharp
weld.Value.WeldType.HasFlag(WeldTypeCode.Bevel) || weld.Value.Placement == WeldLinePlacemet.EdgeEdge
```

So a plain **fillet** weld placed edge-to-edge reports `isFullStrength: true`. A fillet weld does not develop the capacity of the connected plates, so the old wording ("the check *treats it as* a full-strength weld") was doing too much work to defend the name.

## What changed
The text now leads with what the check actually does - it does not rate this weld by a stress utilisation, so the check is satisfied by definition - and calls out the edge-to-edge fillet case explicitly as a caveat to the name. `UnityCheck`'s cross-reference is trimmed to match.

**No identifier changes.** The property stays `IsFullStrength` on the DTO, `isFullStrength` in `openapi.yaml` and the C# docs, and `is_full_strength` in the Python model. Verified: zero rename tokens in the net diff against `main`, so nothing breaks for consumers and no client regeneration is required for correctness.

The mapping is also unchanged. Narrowing it to the weld-type condition would leave edge-to-edge welds with a NaN `unityCheck` and no flag at all - exactly the silent-sentinel trap #35764 was raised to remove. The broad mapping is right; only the wording needed fixing.

## Note on the generated files
`openapi.yaml`, both `docs/CheckResWeld.md` and the Python model were edited directly rather than regenerated, since regenerating needs a built API and the generator toolchain. The openapi descriptions are re-emitted as single-line double-quoted YAML scalars instead of the generator's folded form - semantically identical, and validated by parsing the document and asserting both descriptions match the source XML docs exactly. Worth regenerating on top at some point to restore byte-parity; nothing depends on it.

AI-assisted PR - human review required