### PR TITLE
#35762: Replace bulk CalculateAsync overload with connection-scoped m…

### DIFF
--- a/src/IdeaStatiCa.Api/Connection/IConnectionApiController.cs
+++ b/src/IdeaStatiCa.Api/Connection/IConnectionApiController.cs
@@ -110,16 +110,27 @@ namespace IdeaStatiCa.Api.Connection
 		Task<List<ConResultSummary>> CalculateAsync(List<int> conToCalculateIds, CancellationToken cancellationToken = default);
 
 		/// <summary>
-		/// As <see cref="CalculateAsync(List{int}, CancellationToken)"/>, but when <paramref name="loadEffectIds"/>
-		/// is set the analysis solves exactly these load effects in every calculated connection - their Active flags
-		/// are ignored and nothing is persisted; results reflect only this subset until the next calculation.
-		/// Null = all active load effects. Unknown or empty ids are rejected with 422.
+		/// Run CBFEM analysis of a single connection. When <paramref name="loadEffectIds"/> is set the analysis
+		/// solves exactly these load effects of the connection - their Active flags are ignored and nothing is
+		/// persisted; results reflect only this subset until the next calculation.
+		/// Null = all active load effects. Unknown ids are rejected with 422.
 		/// </summary>
-		/// <param name="conToCalculateIds">List of connections in the active project to calculate</param>
+		/// <param name="connectionId">Id of the connection in the active project to calculate</param>
 		/// <param name="loadEffectIds">Subset of load-effect ids to solve, or null for all active load effects</param>
 		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
-		Task<List<ConResultSummary>> CalculateAsync(List<int> conToCalculateIds, IEnumerable<int> loadEffectIds, CancellationToken cancellationToken = default);
+		/// <returns>Result summary of the connection</returns>
+		Task<ConResultSummary> CalculateConnectionAsync(int connectionId, IEnumerable<int> loadEffectIds = null, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Run CBFEM analysis of a single connection and get a JSON string which represents its raw CBFEM
+		/// results (an instance of CheckResultsData). Subset semantics of <paramref name="loadEffectIds"/>
+		/// are the same as in <see cref="CalculateConnectionAsync(int, IEnumerable{int}, CancellationToken)"/>.
+		/// </summary>
+		/// <param name="connectionId">Id of the connection in the active project to calculate</param>
+		/// <param name="loadEffectIds">Subset of load-effect ids to solve, or null for all active load effects</param>
+		/// <param name="cancellationToken"></param>
+		/// <returns>JSON string representing an instance of CheckResultsData</returns>
+		Task<string> GetConnectionRawResultsAsync(int connectionId, IEnumerable<int> loadEffectIds = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Get detailed calculation results for  <paramref name="conToCalculateIds"/>


### PR DESCRIPTION
…ethods

Per API review the load-effect subset selector belongs to a single-connection calculate: CalculateConnectionAsync(connectionId, loadEffectIds) and GetConnectionRawResultsAsync(connectionId, loadEffectIds) replace the CalculateAsync(conToCalculateIds, loadEffectIds) overload - a flat id list across multiple connections was ambiguous. Matches new REST endpoints POST connections/{connectionId}/calculate and /rawresults-text.

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
