### PR TITLE
#35766: Add async calculation job model (start/poll/cancel)

### DIFF
--- a/src/IdeaStatiCa.Api/Connection/ConRestApiConstants.cs
+++ b/src/IdeaStatiCa.Api/Connection/ConRestApiConstants.cs
@@ -16,6 +16,7 @@
 		public const string Client = "clients";
 		public const string Templates = "templates";
 		public const string ConnectionLibrary = "connection-library";
+		public const string CalculationJobs = "calculation-jobs";
 
 		public const string ConnectClient = "connect-client";
 		public const string Version = "version";

--- a/src/IdeaStatiCa.Api/Connection/IConnectionApiController.cs
+++ b/src/IdeaStatiCa.Api/Connection/IConnectionApiController.cs
@@ -133,6 +133,49 @@ namespace IdeaStatiCa.Api.Connection
 		Task<string> GetConnectionRawResultsAsync(int connectionId, IEnumerable<int> loadEffectIds = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
+		/// Start an asynchronous CBFEM calculation job for <paramref name="conToCalculateIds"/>.
+		/// Returns immediately with the accepted job; poll it with
+		/// <see cref="GetCalculationJobAsync(Guid, CancellationToken)"/> and cancel it with
+		/// <see cref="CancelCalculationJobAsync(Guid, CancellationToken)"/>. At most one job can be
+		/// active per project - starting a second one is rejected (409).
+		/// </summary>
+		/// <param name="conToCalculateIds">List of connections in the active project to calculate</param>
+		/// <param name="cancellationToken"></param>
+		/// <returns>The accepted job</returns>
+		Task<ConCalculationJob> StartCalculationAsync(List<int> conToCalculateIds, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Start an asynchronous CBFEM calculation job for a single connection. Subset semantics of
+		/// <paramref name="loadEffectIds"/> are the same as in
+		/// <see cref="CalculateConnectionAsync(int, IEnumerable{int}, CancellationToken)"/>.
+		/// </summary>
+		/// <param name="connectionId">Id of the connection in the active project to calculate</param>
+		/// <param name="loadEffectIds">Subset of load-effect ids to solve, or null for all active load effects</param>
+		/// <param name="cancellationToken"></param>
+		/// <returns>The accepted job</returns>
+		Task<ConCalculationJob> StartConnectionCalculationAsync(int connectionId, IEnumerable<int> loadEffectIds = null, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Get the current state of an asynchronous calculation job, including progress of the
+		/// running solve and result summaries once finished.
+		/// </summary>
+		/// <param name="jobId">Id of the job returned by the start methods</param>
+		/// <param name="cancellationToken"></param>
+		/// <returns>The job state</returns>
+		Task<ConCalculationJob> GetCalculationJobAsync(Guid jobId, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Request cancellation of an asynchronous calculation job: the running solver process is
+		/// stopped and remaining connections are skipped. Interrupted connections stay not-calculated.
+		/// Idempotent - cancelling an already finished job leaves it unchanged. Cancellation is
+		/// asynchronous; poll <see cref="GetCalculationJobAsync(Guid, CancellationToken)"/> for the
+		/// terminal state.
+		/// </summary>
+		/// <param name="jobId">Id of the job returned by the start methods</param>
+		/// <param name="cancellationToken"></param>
+		Task CancelCalculationJobAsync(Guid jobId, CancellationToken cancellationToken = default);
+
+		/// <summary>
 		/// Get detailed calculation results for  <paramref name="conToCalculateIds"/>
 		/// </summary>
 		/// <param name="conToCalculateIds">List of connections in the active project</param>

--- a/src/IdeaStatiCa.Api/Connection/Model/Calculation/ConCalculationJob.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Calculation/ConCalculationJob.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace IdeaStatiCa.Api.Connection.Model
+{
+	/// <summary>
+	/// State of an asynchronous CBFEM calculation job started by the calculate-async endpoints.
+	/// At most one job can be active per project; poll it by <see cref="JobId"/> and cancel it
+	/// with the DELETE endpoint.
+	/// </summary>
+	public class ConCalculationJob
+	{
+		/// <summary>Identifier used to poll and cancel the job.</summary>
+		public Guid JobId { get; set; }
+
+		/// <summary>Id of the project the job calculates in.</summary>
+		public Guid ProjectId { get; set; }
+
+		public ConCalculationJobStatusEnum Status { get; set; }
+
+		/// <summary>Connections the job calculates, in execution order.</summary>
+		public List<int> ConnectionIds { get; set; }
+
+		/// <summary>Number of connections whose calculation has finished (successfully or not).</summary>
+		public int ConnectionsCompleted { get; set; }
+
+		/// <summary>Id of the connection currently being calculated; null when not running.</summary>
+		public int? CurrentConnectionId { get; set; }
+
+		/// <summary>
+		/// Progress of the current connection's solve as a fraction (0-1), stepping once per solved
+		/// load case - the value the desktop progress bar consumes. Coarse by design: it reports which
+		/// load case is being solved, not progress within it.
+		/// </summary>
+		public double Percent { get; set; }
+
+		/// <summary>Last progress message from the solver (current load case and iteration), if any.</summary>
+		public string Message { get; set; }
+
+		public DateTime CreatedAt { get; set; }
+
+		public DateTime? FinishedAt { get; set; }
+
+		/// <summary>Result summaries of the calculated connections; populated when the job finishes.</summary>
+		public List<ConResultSummary> Results { get; set; }
+
+		/// <summary>Failure reason; populated when the job status is <see cref="ConCalculationJobStatusEnum.Failed"/>.</summary>
+		public string Error { get; set; }
+	}
+}

--- a/src/IdeaStatiCa.Api/Connection/Model/Calculation/ConCalculationJobStatusEnum.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Calculation/ConCalculationJobStatusEnum.cs
@@ -1,0 +1,23 @@
+﻿namespace IdeaStatiCa.Api.Connection.Model
+{
+	/// <summary>
+	/// Lifecycle state of an asynchronous CBFEM calculation job.
+	/// </summary>
+	public enum ConCalculationJobStatusEnum
+	{
+		/// <summary>The job was accepted and waits for the project to become available.</summary>
+		Queued,
+
+		/// <summary>The job is calculating.</summary>
+		Running,
+
+		/// <summary>All requested connections were calculated; <c>Results</c> holds their summaries.</summary>
+		Finished,
+
+		/// <summary>The job ended with an error; <c>Error</c> holds the reason.</summary>
+		Failed,
+
+		/// <summary>The job was cancelled; connections whose solve was interrupted stay not-calculated.</summary>
+		Cancelled
+	}
+}


### PR DESCRIPTION
ConCalculationJob + status enum and IConnectionApiController methods for the async calculate job model: StartCalculationAsync (bulk) / StartConnectionCalculationAsync (single connection, optional loadEffectIds subset per #35762 semantics), GetCalculationJobAsync polling with per-load-case progress, CancelCalculationJobAsync stopping the running solver. One active job per project. Matches new REST endpoints POST connections/calculate-async, GET/DELETE calculation-jobs/{jobId}.

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
