### PR TITLE
#34800: Map non-positive API client timeout to InfiniteTimeSpan inste…

### DIFF
--- a/src/api-sdks/connection-api/clients/csharp/.openapi-generator-ignore
+++ b/src/api-sdks/connection-api/clients/csharp/.openapi-generator-ignore
@@ -21,3 +21,8 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+
+# ApiClient.cs carries a manual fix (#34800): a non-positive configured timeout maps to
+# Timeout.InfiniteTimeSpan, because RestSharp resolves a null Timeout to its 100 s default.
+# Regeneration would silently revert it, so the generator must skip this file.
+src/IdeaStatiCa.ConnectionApi/Client/ApiClient.cs

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/Client/ApiClient.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/Client/ApiClient.cs
@@ -460,7 +460,8 @@ namespace IdeaStatiCa.ConnectionApi.Client
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                Timeout = configuration.Timeout > 0 ? TimeSpan.FromMilliseconds(configuration.Timeout) : (TimeSpan?)null,
+                // RestSharp resolves a null Timeout to its 100 s default; only InfiniteTimeSpan means "no timeout".
+                Timeout = configuration.Timeout > 0 ? TimeSpan.FromMilliseconds(configuration.Timeout) : System.Threading.Timeout.InfiniteTimeSpan,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -569,7 +570,8 @@ namespace IdeaStatiCa.ConnectionApi.Client
 			var clientOptions = new RestClientOptions(baseUrl)
 			{
 				ClientCertificates = configuration.ClientCertificates,
-				Timeout = configuration.Timeout > 0 ? TimeSpan.FromMilliseconds(configuration.Timeout) : (TimeSpan?)null,
+				// RestSharp resolves a null Timeout to its 100 s default; only InfiniteTimeSpan means "no timeout".
+				Timeout = configuration.Timeout > 0 ? TimeSpan.FromMilliseconds(configuration.Timeout) : System.Threading.Timeout.InfiniteTimeSpan,
 				Proxy = configuration.Proxy,
 				UserAgent = configuration.UserAgent,
 				UseDefaultCredentials = configuration.UseDefaultCredentials,


### PR DESCRIPTION
…ad of null

RestSharp 112 resolves a null Timeout as request.Timeout ?? Options.Timeout ?? _defaultTimeout (100 s), so Timeout.Infinite requests were aborted at ~100 s while the service kept calculating and finished successfully. Guard the hand-edit of the generated ApiClient.cs via .openapi-generator-ignore.

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
