### PR TITLE
Let a BIM link add arguments for the IDEA StatiCa application it starts

### DIFF
--- a/src/IdeaStatiCa.BimApiLink/ApplicationBimRunnable.cs
+++ b/src/IdeaStatiCa.BimApiLink/ApplicationBimRunnable.cs
@@ -19,6 +19,7 @@ namespace IdeaStatiCa.BimApiLink
 		private readonly string _name;
 		private readonly string _ideaStatiCaPath;
 		private readonly string _projectPath;
+		private readonly string _ideaStatiCaArguments;
 
 		internal ApplicationBimRunnable(
 			IApplicationBIM app,
@@ -26,7 +27,8 @@ namespace IdeaStatiCa.BimApiLink
 			IPluginLogger logger,
 			string name,
 			string ideaStatiCaPath,
-			string projectPath)
+			string projectPath,
+			string ideaStatiCaArguments = null)
 		{
 			Debug.Assert(app != null);
 			Debug.Assert(bimHostingFactory != null);
@@ -41,6 +43,7 @@ namespace IdeaStatiCa.BimApiLink
 			_name = name;
 			_ideaStatiCaPath = ideaStatiCaPath;
 			_projectPath = projectPath;
+			_ideaStatiCaArguments = ideaStatiCaArguments;
 		}
 
 		public Task Run()
@@ -48,7 +51,8 @@ namespace IdeaStatiCa.BimApiLink
 			PluginFactory pluginFactory = new PluginFactory(
 				this,
 				_name,
-				_ideaStatiCaPath);
+				_ideaStatiCaPath,
+				_ideaStatiCaArguments);
 
 			IBIMPluginHosting pluginHosting = _bimHostingFactory.Create(pluginFactory, _logger);
 

--- a/src/IdeaStatiCa.BimApiLink/BimLink.cs
+++ b/src/IdeaStatiCa.BimApiLink/BimLink.cs
@@ -17,6 +17,7 @@ namespace IdeaStatiCa.BimApiLink
 		protected string ApplicationName { get; }
 
 		private string _ideaStatiCaPath;
+		private string _ideaStatiCaArguments;
 		private IPluginLogger _pluginLogger;
 		private ResultsImportersConfiguration _resultsImportersConfiguration;
 		private BimImporterConfiguration _bimImporterConfiguration;
@@ -41,6 +42,19 @@ namespace IdeaStatiCa.BimApiLink
 		public BimLink WithIdeaStatiCa(string path)
 		{
 			_ideaStatiCaPath = path;
+			return this;
+		}
+
+		/// <summary>
+		/// Extra arguments for the IDEA StatiCa application, appended to the ones the host always passes
+		/// (<c>-automation</c>, <c>-project</c>, <c>-grpcPort</c>). Use it when the link has already collected what the
+		/// application would otherwise ask for — a project's design codes, say, so Checkbot creates it rather than
+		/// opening its New Project page (<c>-new -designCode:…</c>).
+		/// </summary>
+		/// <remarks>Not calling this leaves the command line exactly as it has always been.</remarks>
+		public BimLink WithIdeaStatiCaArguments(string arguments)
+		{
+			_ideaStatiCaArguments = arguments;
 			return this;
 		}
 
@@ -168,7 +182,8 @@ namespace IdeaStatiCa.BimApiLink
 				pluginLogger,
 				ApplicationName,
 				_ideaStatiCaPath,
-				_projectPath);
+				_projectPath,
+				_ideaStatiCaArguments);
 		}
 
 		private IApplicationBIM CreateApplicationBIM(IModel model, IPluginLogger pluginLogger, IProgressMessaging progressMessaging = null)

--- a/src/IdeaStatiCa.BimApiLink/Plugin/PluginFactory.cs
+++ b/src/IdeaStatiCa.BimApiLink/Plugin/PluginFactory.cs
@@ -2,19 +2,23 @@
 
 namespace IdeaStatiCa.BimApiLink.Plugin
 {
-	internal class PluginFactory : IBIMPluginFactory
+	internal class PluginFactory : IBIMPluginFactoryWithArguments
 	{
 		public string FeaAppName { get; }
 
 		public string IdeaStaticaAppPath { get; }
 
+		/// <inheritdoc />
+		public string IdeaStaticaAppArguments { get; }
+
 		private readonly IApplicationBIM _application;
 
-		public PluginFactory(IApplicationBIM application, string applicationName, string ideaStatiCaPath)
+		public PluginFactory(IApplicationBIM application, string applicationName, string ideaStatiCaPath, string ideaStatiCaArguments = null)
 		{
 			_application = application;
 			FeaAppName = applicationName;
 			IdeaStaticaAppPath = ideaStatiCaPath;
+			IdeaStaticaAppArguments = ideaStatiCaArguments;
 		}
 
 		public IApplicationBIM Create()

--- a/src/IdeaStatiCa.Plugin.Tests/gRPC/BIMPluginHostingGrpcArgumentsTest.cs
+++ b/src/IdeaStatiCa.Plugin.Tests/gRPC/BIMPluginHostingGrpcArgumentsTest.cs
@@ -1,0 +1,53 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+
+namespace IdeaStatiCa.Plugin.Tests.gRPC
+{
+	/// <summary>
+	/// The command line the host starts the IDEA StatiCa application with. A link may add to it — one that already
+	/// collected a project's design codes needs Checkbot to create the project rather than ask for them — through the
+	/// opt-in <see cref="IBIMPluginFactoryWithArguments"/>.
+	/// </summary>
+	[TestFixture]
+	public class BIMPluginHostingGrpcArgumentsTest
+	{
+		[Test]
+		public void WithoutExtraArguments_TheCommandLineIsTheOneItAlwaysWas()
+		{
+			string arguments = BIMPluginHostingGrpc.BuildIdeaStatiCaArguments("1234", @"D:\projects\Bridge", 50000, null);
+
+			arguments.Should().Be(@"-automation:1234 -project:""D:\projects\Bridge"" -grpcPort:50000");
+		}
+
+		[TestCase("")]
+		[TestCase("   ")]
+		public void AnEmptyExtraArgument_ChangesNothing(string extraArguments)
+		{
+			string arguments = BIMPluginHostingGrpc.BuildIdeaStatiCaArguments("1234", @"D:\projects\Bridge", 50000, extraArguments);
+
+			arguments.Should().Be(@"-automation:1234 -project:""D:\projects\Bridge"" -grpcPort:50000");
+		}
+
+		[Test]
+		public void ExtraArguments_AreAppendedAfterTheHostsOwn()
+		{
+			string arguments = BIMPluginHostingGrpc.BuildIdeaStatiCaArguments(
+				"1234",
+				@"D:\projects\Bridge",
+				50000,
+				"-new -designCode:ECEN -steelCodeEdition:EN_1993_1_8_2024");
+
+			arguments.Should().Be(
+				@"-automation:1234 -project:""D:\projects\Bridge"" -grpcPort:50000 -new -designCode:ECEN -steelCodeEdition:EN_1993_1_8_2024");
+		}
+
+		// The project directory stays the host's to decide, so a quoted path with spaces must survive intact.
+		[Test]
+		public void AProjectPathWithSpaces_StaysQuoted()
+		{
+			string arguments = BIMPluginHostingGrpc.BuildIdeaStatiCaArguments("1234", @"D:\my projects\Office block", 50000, "-new");
+
+			arguments.Should().Contain(@"-project:""D:\my projects\Office block""");
+		}
+	}
+}

--- a/src/IdeaStatiCa.Plugin/Grpc/BIMPluginHostingGrpc.cs
+++ b/src/IdeaStatiCa.Plugin/Grpc/BIMPluginHostingGrpc.cs
@@ -201,10 +201,22 @@ namespace IdeaStatiCa.Plugin
 			Process connectionProc = new Process();
 			ideaLogger.LogDebug($"BIMPluginHostingGrpc.RunIdeaIdeaStatiCa  strarting exePath = '{exePath}', id = '{id}', grpcPort = {GrpcCommunicator.Port} ");
 			string eventName = string.Format("{0}{1}", EventName, id);
+
+			// A factory may have more to say than the project directory - a link that already collected the project's
+			// design codes needs the application to create it. Opt-in through a separate interface, so a factory that
+			// does not implement it gets exactly the command line it always got.
+			string extraArguments = (bimPluginFactory as IBIMPluginFactoryWithArguments)?.IdeaStaticaAppArguments;
+			if (!string.IsNullOrWhiteSpace(extraArguments))
+			{
+				ideaLogger.LogDebug($"BIMPluginHostingGrpc.RunIdeaIdeaStatiCa  extra arguments = '{extraArguments}'");
+			}
+
 			using (EventWaitHandle syncEvent = new EventWaitHandle(false, EventResetMode.AutoReset, eventName))
 			{
 				// disable only recent files
-				connectionProc.StartInfo = new ProcessStartInfo(exePath, $"{Constants.AutomationParam}:{id} {Constants.ProjectParam}:\"{workingDirectory}\" {Constants.GrpcControlPortParam}:{GrpcCommunicator.Port}");
+				connectionProc.StartInfo = new ProcessStartInfo(
+					exePath,
+					BuildIdeaStatiCaArguments(id, workingDirectory, GrpcCommunicator.Port, extraArguments));
 				connectionProc.EnableRaisingEvents = true;
 				connectionProc.Start();
 
@@ -221,6 +233,18 @@ namespace IdeaStatiCa.Plugin
 			}
 
 			return connectionProc;
+		}
+
+		/// <summary>
+		/// The command line the IDEA StatiCa application is started with: the three arguments the host has always
+		/// passed, plus whatever a <see cref="IBIMPluginFactoryWithArguments"/> factory added. Split out from the
+		/// launch itself so the appending can be tested without starting a process.
+		/// </summary>
+		internal static string BuildIdeaStatiCaArguments(string id, string workingDirectory, int grpcPort, string extraArguments)
+		{
+			string arguments = $"{Constants.AutomationParam}:{id} {Constants.ProjectParam}:\"{workingDirectory}\" {Constants.GrpcControlPortParam}:{grpcPort}";
+
+			return string.IsNullOrWhiteSpace(extraArguments) ? arguments : $"{arguments} {extraArguments}";
 		}
 
 		/// <summary>

--- a/src/IdeaStatiCa.Plugin/IBIMPluginFactory.cs
+++ b/src/IdeaStatiCa.Plugin/IBIMPluginFactory.cs
@@ -19,4 +19,24 @@ namespace IdeaStatiCa.Plugin
 
 		string IdeaStaticaAppPath { get; }
 	}
+
+	/// <summary>
+	/// A factory that also wants extra arguments passed to the IDEA StatiCa application it names. Implement this
+	/// alongside <see cref="IBIMPluginFactory"/> when the link has more to say than the project directory — for
+	/// example a link that collected the project's design codes up front and needs the application to create it
+	/// (<c>-new -designCode:…</c>).
+	/// </summary>
+	/// <remarks>
+	/// Deliberately a separate interface rather than another member on <see cref="IBIMPluginFactory"/>: that one is
+	/// implemented by links built outside this repository, and adding a member would break every one of them. A
+	/// factory that does not implement this is passed the same command line as before.
+	/// </remarks>
+	public interface IBIMPluginFactoryWithArguments : IBIMPluginFactory
+	{
+		/// <summary>
+		/// Arguments appended to the ones the host always passes (<c>-automation</c>, <c>-project</c>,
+		/// <c>-grpcPort</c>). Null or empty changes nothing.
+		/// </summary>
+		string IdeaStaticaAppArguments { get; }
+	}
 }

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCaClient.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCaClient.cs
@@ -84,7 +84,15 @@ namespace IdeaStatiCa.TeklaStructuresPlugin
             }
         }
 
-        public Task Run()
+        /// <param name="checkbotProjectPath">
+        /// The Checkbot project to use. Null derives it from the open model, as it always has; pass one when the
+        /// project was chosen elsewhere — the Checkbot launcher asks the user where it should go.
+        /// </param>
+        /// <param name="checkbotArguments">
+        /// Extra arguments for Checkbot, appended to the ones the host passes. Use it together with a project the
+        /// launcher chose but that does not exist yet, so Checkbot creates it (<c>-new -designCode:…</c>).
+        /// </param>
+        public Task Run(string checkbotProjectPath = null, string checkbotArguments = null)
         {
             pluginLogger?.LogInformation("Run - Method started");
             try
@@ -96,7 +104,9 @@ namespace IdeaStatiCa.TeklaStructuresPlugin
                 pluginLogger?.LogInformation($"Run - IModelClient resolved: {modelClient?.GetType().FullName}");
 
                 pluginLogger?.LogInformation("Run - Creating project directory");
-                string projectPath = CreateProjectDirectory(modelClient);
+                string projectPath = string.IsNullOrWhiteSpace(checkbotProjectPath)
+                    ? CreateProjectDirectory(modelClient)
+                    : checkbotProjectPath;
                 pluginLogger?.LogInformation($"Run - Project path: {projectPath}");
 
                 pluginLogger?.LogInformation("Run - Getting Checkbot location");
@@ -105,7 +115,8 @@ namespace IdeaStatiCa.TeklaStructuresPlugin
 
                 pluginLogger?.LogInformation("Run - Creating BimLink");
                 BimLink bimLink = TeklaCadBimLink.Create(LinkName, projectPath)
-                    .WithIdeaStatiCa(checkbotLocation);
+                    .WithIdeaStatiCa(checkbotLocation)
+                    .WithIdeaStatiCaArguments(checkbotArguments);
 
                 pluginLogger?.LogInformation("Run - Resolving AppVisibility");
                 AppVisibility appVisibility = container.Resolve<AppVisibility>();


### PR DESCRIPTION
The host builds the command line itself - -automation, -project, -grpcPort - so a link had no way to say anything else. The Checkbot launcher collects a project's name, folder and design codes before Checkbot starts, and Checkbot can create the project from them (-new -designCode:...), but the arguments could not reach it.

- IBIMPluginFactoryWithArguments is a new, optional interface beside IBIMPluginFactory. Deliberately separate rather than another member on the existing one: links built outside this repository implement it, and a new member would break every one of them.
- BimLink.WithIdeaStatiCaArguments passes them through PluginFactory to the hosting. A link that does not call it gets exactly the command line it always got - the assembly is split into BuildIdeaStatiCaArguments so that is covered by a test rather than asserted in a comment.
- The Tekla link's Run also takes the project path, because the launcher asks the user where the project should go; null keeps deriving it from the open model.

Work item 36021.

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
