### PR TITLE
#36161: Rename ConCalculationJob.Percent to Progress and feed its doc…

### DIFF
--- a/src/IdeaStatiCa.Api/Connection/Model/Calculation/ConCalculationJob.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Calculation/ConCalculationJob.cs
@@ -32,7 +32,7 @@ namespace IdeaStatiCa.Api.Connection.Model
 		/// load case - the value the desktop progress bar consumes. Coarse by design: it reports which
 		/// load case is being solved, not progress within it.
 		/// </summary>
-		public double Percent { get; set; }
+		public double Progress { get; set; }
 
 		/// <summary>Last progress message from the solver (current load case and iteration), if any.</summary>
 		public string Message { get; set; }


### PR DESCRIPTION
…s into swagger

Progress is a 0..1 fraction stepping per solved load case; the old name collided with percentage-based loading (ConLoadEffect.IsPercentage). IdeaStatiCa.Api now generates its XML doc file so the Connection service can include contract descriptions in the swagger document; the remaining undocumented job fields got descriptions. Clients pick the rename up at the next regeneration.

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
