### PR TITLE
[DO NOT MERGE separately] #33121 parametric css dimension code names + shape catalog client methods

### DIFF
--- a/src/IdeaRS.OpenModel/Libraries/CrossSection/CrossSectionFactory.Steel.cs
+++ b/src/IdeaRS.OpenModel/Libraries/CrossSection/CrossSectionFactory.Steel.cs
@@ -475,7 +475,9 @@
 
 		public static void FillWeldedTriangle(CrossSectionParameter css, double h, double w, double fTh, double webTh, double webD, bool mirrorY = false)
 		{
-			css.CrossSectionType = CrossSectionType.BoxFl;
+			// BoxTriangle, not BoxFl: the importer routes on this stamp, and ConvertBoxFl throws
+			// on the missing 'UpperFlangeWidth' — with BoxFl every FillWeldedTriangle caller broke
+			css.CrossSectionType = CrossSectionType.BoxTriangle;
 			css.Parameters.Add(new ParameterDouble() { Name = "FlangeThickness", Value = fTh });
 			css.Parameters.Add(new ParameterDouble() { Name = "Height", Value = h });
 			css.Parameters.Add(new ParameterDouble() { Name = "WebDistance", Value = webD });

--- a/src/IdeaStatiCa.Api/Connection/IConnectionApiController.cs
+++ b/src/IdeaStatiCa.Api/Connection/IConnectionApiController.cs
@@ -416,6 +416,24 @@ namespace IdeaStatiCa.Api.Connection
 		Task<ConCrossSectionDetail> UpdateParametricCrossSectionAsync(int cssId, ConCrossSectionParametricDefinition definition, CancellationToken cancellationToken = default);
 
 		/// <summary>
+		/// List the shape types the parametric cross-section endpoints accept. BETA.
+		/// </summary>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns>The parametric shape type names (e.g. "Iw", "Tw", "CHSPar")</returns>
+		Task<List<string>> GetParametricCrossSectionShapesAsync(CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Get the fill-in template of a parametric shape: every dimension with its stable id,
+		/// stable code name (e.g. "wH") and the shape's default value, in SI units. Change the
+		/// values, set the material, and create the section with
+		/// <see cref="AddParametricCrossSectionAsync"/>. BETA.
+		/// </summary>
+		/// <param name="shapeType">Shape type name from <see cref="GetParametricCrossSectionShapesAsync"/></param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns>The shape's default definition — ids, code names and default dimension values</returns>
+		Task<ConCrossSectionParametricDefinition> GetParametricCrossSectionShapeTemplateAsync(string shapeType, CancellationToken cancellationToken = default);
+
+		/// <summary>
 		/// Add bolt assembly to project data
 		/// </summary>
 		/// <param name="newBa"></param>

--- a/src/IdeaStatiCa.Api/Connection/Model/Material/ConCrossSectionDefinition.cs
+++ b/src/IdeaStatiCa.Api/Connection/Model/Material/ConCrossSectionDefinition.cs
@@ -53,12 +53,18 @@ namespace IdeaStatiCa.Api.Connection.Model.Material
 	}
 
 	/// <summary>
-	/// One dimension of a parametric cross-section. Identified by the shape's stable numeric
-	/// parameter id — display captions are localized and deliberately not part of the contract.
+	/// One dimension of a parametric cross-section, identified by the shape's stable numeric
+	/// parameter id and its stable non-localized code name (e.g. "wH" — the engine's parameter
+	/// identifier; display captions are localized and deliberately not part of the contract).
+	/// On input either <see cref="Name"/> or <see cref="Id"/> is enough; when both are given
+	/// they must identify the same dimension.
 	/// </summary>
 	public class ConCrossSectionParameter
 	{
 		public int Id { get; set; }
+
+		/// <summary>Stable non-localized dimension code of the shape (e.g. "wH", "fT").</summary>
+		public string Name { get; set; }
 
 		public double Value { get; set; }
 	}


### PR DESCRIPTION
Companion of Azure DevOps PR 28200 (#33121 increment 3 - parametric cross-section discoverability). ConCrossSectionParameter gains Name (stable non-localized dimension code, e.g. wH); IConnectionApiController gains GetParametricCrossSectionShapesAsync + GetParametricCrossSectionShapeTemplateAsync. Implementation lives in the main repo PR.

**Merge this TOGETHER WITH ADO PR 28200, not before** (interface without implementation breaks develop - the #1256 lesson).

AI-assisted PR - human review required