### PR TITLE
Import each BIM entity once per import instead of twice

### DIFF
--- a/src/IdeaStatiCa.BimImporter.Tests/BimObjectImporterTest.cs
+++ b/src/IdeaStatiCa.BimImporter.Tests/BimObjectImporterTest.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using IdeaRS.OpenModel;
+using IdeaRS.OpenModel.Model;
+using IdeaStatiCa.BimApi;
+using IdeaStatiCa.BimImporter.BimItems;
+using IdeaStatiCa.BimImporter.Importers;
+using IdeaStatiCa.BimImporter.Results;
+using IdeaStatiCa.Plugin;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace IdeaStatiCa.BimImporter.Tests
+{
+	// The sequences handed to Import are deferred: BimImporter.ImportGroup builds them out of
+	// IProject.GetBimObject, which re-reads the entity from the BIM application on every enumeration.
+	// Walking such a sequence a second time imports the whole model a second time.
+	[TestFixture]
+	public class BimObjectImporterTest
+	{
+		private IPluginLogger _logger;
+		private IImporter<IIdeaObject> _importer;
+		private IResultImporter _resultImporter;
+		private IBimResultsProvider _resultsProvider;
+		private IProgressMessaging _remoteApp;
+		private IProject _project;
+		private int _nextIomId;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_logger = Substitute.For<IPluginLogger>();
+			_importer = Substitute.For<IImporter<IIdeaObject>>();
+			_resultImporter = Substitute.For<IResultImporter>();
+			_resultsProvider = Substitute.For<IBimResultsProvider>();
+			_remoteApp = Substitute.For<IProgressMessaging>();
+			_project = Substitute.For<IProject>();
+			_nextIomId = 0;
+
+			_importer.Import(Arg.Any<IImportContext>(), Arg.Any<IIdeaObject>()).Returns(_ => new Member1D());
+			_project.GetIomId(Arg.Any<IIdeaObject>()).Returns(_ => ++_nextIomId);
+		}
+
+		private BimObjectImporter CreateImporter()
+			=> new BimObjectImporter(
+				_logger,
+				_importer,
+				_resultImporter,
+				new BimImporterConfiguration(),
+				_remoteApp,
+				_resultsProvider);
+
+		private static IIdeaObject BimObject(string id)
+		{
+			IIdeaObject obj = Substitute.For<IIdeaObject>();
+			obj.Id.Returns(id);
+
+			return obj;
+		}
+
+		private static IBimItem BimItem(string id)
+		{
+			// Assign first: NSubstitute tracks one "last call" globally, so configuring the referenced
+			// object inside the Returns argument would discard the item's own configuration.
+			IIdeaObject referencedObject = BimObject(id);
+			IBimItem bimItem = Substitute.For<IBimItem>();
+			bimItem.ReferencedObject.Returns(referencedObject);
+			bimItem.Type.Returns(BIMItemType.Member);
+
+			return bimItem;
+		}
+
+		/// <summary>
+		/// A sequence that reports every time its enumeration is started, standing in for the deferred
+		/// GetBimObject chains the production callers pass.
+		/// </summary>
+		private static IEnumerable<T> Deferred<T>(IEnumerable<T> items, Action onEnumerationStarted)
+		{
+			onEnumerationStarted();
+
+			foreach (T item in items)
+			{
+				yield return item;
+			}
+		}
+
+		[Test]
+		public void The_bim_items_are_enumerated_once()
+		{
+			int enumerations = 0;
+			IBimItem[] bimItems = { BimItem("member-1"), BimItem("member-2") };
+
+			CreateImporter().Import(null, Deferred(bimItems, () => enumerations++), _project, CountryCode.ECEN);
+
+			enumerations.Should().Be(1);
+		}
+
+		[Test]
+		public void The_objects_are_enumerated_once()
+		{
+			int enumerations = 0;
+			IIdeaObject[] objects = { BimObject("node-1"), BimObject("node-2") };
+
+			CreateImporter().Import(Deferred(objects, () => enumerations++), null, _project, CountryCode.ECEN);
+
+			enumerations.Should().Be(1);
+		}
+
+		// The count reported to the progress stage is the whole reason Import materializes at all.
+		// Without these, moving the count back behind a null check on the progress sink would restore
+		// the double import while both enumeration tests stayed green.
+		[Test]
+		public void Every_bim_item_is_reported_against_the_total()
+		{
+			IBimItem[] bimItems = { BimItem("member-1"), BimItem("member-2") };
+
+			CreateImporter().Import(null, Deferred(bimItems, () => { }), _project, CountryCode.ECEN);
+
+			Assert.Multiple(() =>
+			{
+				_remoteApp.Received(1).SetStageLocalised(1, 2, Arg.Any<LocalisedMessage>());
+				_remoteApp.Received(1).SetStageLocalised(2, 2, Arg.Any<LocalisedMessage>());
+			});
+		}
+
+		[Test]
+		public void Every_object_is_reported_against_the_total()
+		{
+			IIdeaObject[] objects = { BimObject("node-1"), BimObject("node-2") };
+
+			CreateImporter().Import(Deferred(objects, () => { }), null, _project, CountryCode.ECEN);
+
+			Assert.Multiple(() =>
+			{
+				_remoteApp.Received(1).SetStageLocalised(1, 2, LocalisedMessage.ImportingIOMObject);
+				_remoteApp.Received(1).SetStageLocalised(2, 2, LocalisedMessage.ImportingIOMObject);
+			});
+		}
+	}
+}

--- a/src/IdeaStatiCa.BimImporter/BimObjectImporter.cs
+++ b/src/IdeaStatiCa.BimImporter/BimObjectImporter.cs
@@ -75,11 +75,11 @@ namespace IdeaStatiCa.BimImporter
 
 			if (!(bimItems is null))
 			{
+				IList<IBimItem> items = Materialize(bimItems);
 				int i = 1;
-				int count = bimItems.Count();
-				foreach (IBimItem bimItem in bimItems)
+				foreach (IBimItem bimItem in items)
 				{
-					_remoteApp?.SetStageLocalised(i, count, bimItem is Member ? LocalisedMessage.ImportingMembers : LocalisedMessage.ImportingConnections);
+					_remoteApp?.SetStageLocalised(i, items.Count, bimItem is Member ? LocalisedMessage.ImportingMembers : LocalisedMessage.ImportingConnections);
 					importContext.ImportBimItem(bimItem);
 					i++;
 				}
@@ -88,11 +88,11 @@ namespace IdeaStatiCa.BimImporter
 			if (!(objects is null))
 			{
 				_remoteApp?.SendMessageLocalised(MessageSeverity.Info, LocalisedMessage.InternalImport);
+				IList<IIdeaObject> items = Materialize(objects);
 				int i = 1;
-				int count = objects.Count();
-				foreach (IIdeaObject obj in objects)
+				foreach (IIdeaObject obj in items)
 				{
-					_remoteApp?.SetStageLocalised(i, count, LocalisedMessage.ImportingIOMObject);
+					_remoteApp?.SetStageLocalised(i, items.Count, LocalisedMessage.ImportingIOMObject);
 					importContext.Import(obj);
 					i++;
 				}
@@ -109,5 +109,13 @@ namespace IdeaStatiCa.BimImporter
 				Results = importContext.OpenModelResult
 			};
 		}
+
+		/// <summary>
+		/// Takes the sequence down to a list that can be counted and walked without enumerating it twice.
+		/// Callers pass deferred sequences that re-read every entity from the BIM application on each
+		/// enumeration, so counting one for the progress stage would import the whole model again.
+		/// </summary>
+		private static IList<T> Materialize<T>(IEnumerable<T> source)
+			=> source as IList<T> ?? source.ToList();
 	}
 }


### PR DESCRIPTION
`BimObjectImporter.Import` counted its input sequences for the progress stage, then
enumerated them again. Callers pass deferred sequences built from `IProject.GetBimObject`,
which re-reads the entity from the BIM application on every enumeration — so the counting
pass silently imported the whole model a second time. Fixed by materializing once.

Affects the `Substructure` and `Members2D` branches of `BimImporter.ImportGroup`, i.e. every
FEA/CAD link's member sync and the Model Coordinator pull. The `Connections` branch and
`ImportMembers` already passed materialized lists.

## Evidence

Measured on SAP2000, 62 selected members, counting `Creating member` in the link log:

| | imports per member |
|---|---|
| before | 3 |
| after | 2 |

The remaining duplicate is a separate issue in the Model Coordinator path
(`SelectionOnlyImport` plus an uncached `ProjectAdapter`) and is not addressed here.

## Tests

`BimObjectImporterTest` — 4 new tests, verified red before the fix and green after, on
net48 and net10.0:
- both sequences are enumerated exactly once
- every item is reported to the progress stage against the real total, so re-introducing
  the count behind a null check on the progress sink cannot pass

Full `IdeaStatiCa.BimImporter.Tests` suite: 115/115 on both target frameworks.

AI-assisted PR - human review required