### PR TITLE
Add IBimImporter.ImportSubstructure for callers that already hold the members

### DIFF
--- a/src/IdeaStatiCa.BimImporter.Tests/BimImporterTest.cs
+++ b/src/IdeaStatiCa.BimImporter.Tests/BimImporterTest.cs
@@ -5,6 +5,7 @@ using IdeaStatiCa.BimImporter.Tests.Helpers;
 using IdeaStatiCa.Plugin;
 using NSubstitute;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -565,6 +566,132 @@ namespace IdeaStatiCa.BimImporter.Tests
 								builder.Members[1],
 								builder.Members[2],
 							})
+						}, _connectionEqualityComparer)),
+					Arg.Any<IProject>(), IdeaRS.OpenModel.CountryCode.ECEN);
+		}
+
+		// The point of ImportSubstructure is that it imports the members it is handed. Resolving them
+		// through the project instead would read every entity from the BIM application a second time.
+		[Test]
+		public void ImportSubstructure_BimObjectImporterShouldReceiveACallWithMemberBimItems()
+		{
+			// Setup
+			GeometryBuilder builder = new GeometryBuilder();
+			builder
+				.Member(1, "line(0,1)")
+				.Member(2, "line(1,2)");
+
+			project = Substitute.For<IProject>();
+
+			BimImporter bimImporter = CreateBimImporter(builder.GetModel());
+
+			// Tested method
+			bimImporter.ImportSubstructure(
+				new List<IIdeaMember1D>() { builder.Members[1], builder.Members[2] },
+				IdeaRS.OpenModel.CountryCode.ECEN);
+
+			// Assert
+			bimObjectImporter.Received()
+				.Import(
+					Arg.Any<IEnumerable<IIdeaObject>>(),
+					Arg.Is<IEnumerable<IBimItem>>(x =>
+						Enumerable.SequenceEqual(x, new List<IBimItem>()
+						{
+							new Member(builder.Members[1]),
+							new Member(builder.Members[2]),
+						}, _connectionEqualityComparer)),
+					Arg.Any<IProject>(), IdeaRS.OpenModel.CountryCode.ECEN);
+		}
+
+		[Test]
+		public void ImportSubstructure_ShouldNotResolveTheMembersThroughTheProject()
+		{
+			// Setup
+			GeometryBuilder builder = new GeometryBuilder();
+			builder.Member(1, "line(0,1)");
+
+			project = Substitute.For<IProject>();
+
+			BimImporter bimImporter = CreateBimImporter(builder.GetModel());
+
+			// Tested method
+			bimImporter.ImportSubstructure(
+				new List<IIdeaMember1D>() { builder.Members[1] },
+				IdeaRS.OpenModel.CountryCode.ECEN);
+
+			// Assert. The bim items are handed over as a deferred sequence, so the matcher has to walk it —
+			// without that the substitute never enumerates and a project lookup inside would go unnoticed.
+			bimObjectImporter.Received()
+				.Import(
+					Arg.Any<IEnumerable<IIdeaObject>>(),
+					Arg.Is<IEnumerable<IBimItem>>(x => x.Count() == 1),
+					Arg.Any<IProject>(), IdeaRS.OpenModel.CountryCode.ECEN);
+
+			project.DidNotReceive().GetBimObject(Arg.Any<int>());
+		}
+
+		// The members must hold the leading IOM ids. ImportContext maps a member only after the geometry it
+		// references, so without the up-front mapping the members scatter through the numbering and every
+		// entity in the exported model lands on a different id.
+		[Test]
+		public void ImportSubstructure_TheMembersTakeTheLeadingIomIds()
+		{
+			// Setup: the real Project, so the ids are the ones the import would actually assign
+			GeometryBuilder builder = new GeometryBuilder();
+			builder
+				.Member(1, "line(0,1)")
+				.Member(2, "line(1,2)");
+
+			BimImporter bimImporter = CreateBimImporter(builder.GetModel());
+
+			// Tested method
+			bimImporter.ImportSubstructure(
+				new List<IIdeaMember1D>() { builder.Members[1], builder.Members[2] },
+				IdeaRS.OpenModel.CountryCode.ECEN);
+
+			// Assert: GetIomId is idempotent, so this reads back what was assigned
+			Assert.Multiple(() =>
+			{
+				Assert.That(project.GetIomId(builder.Members[1]), Is.EqualTo(1));
+				Assert.That(project.GetIomId(builder.Members[2]), Is.EqualTo(2));
+			});
+		}
+
+		[Test]
+		public void ImportSubstructure_MembersIsNull_ThrowsArgumentNullException()
+		{
+			GeometryBuilder builder = new GeometryBuilder();
+			BimImporter bimImporter = CreateBimImporter(builder.GetModel());
+
+			Assert.That(
+				() => bimImporter.ImportSubstructure(null, IdeaRS.OpenModel.CountryCode.ECEN),
+				Throws.InstanceOf<ArgumentNullException>());
+		}
+
+		[Test]
+		public void ImportSubstructure_MemberIsNull_IsSkipped()
+		{
+			// Setup: a member the link could not resolve arrives as null, as it does from IBimApiImporter.Get
+			GeometryBuilder builder = new GeometryBuilder();
+			builder.Member(1, "line(0,1)");
+
+			project = Substitute.For<IProject>();
+
+			BimImporter bimImporter = CreateBimImporter(builder.GetModel());
+
+			// Tested method
+			bimImporter.ImportSubstructure(
+				new List<IIdeaMember1D>() { builder.Members[1], null },
+				IdeaRS.OpenModel.CountryCode.ECEN);
+
+			// Assert
+			bimObjectImporter.Received()
+				.Import(
+					Arg.Any<IEnumerable<IIdeaObject>>(),
+					Arg.Is<IEnumerable<IBimItem>>(x =>
+						Enumerable.SequenceEqual(x, new List<IBimItem>()
+						{
+							new Member(builder.Members[1]),
 						}, _connectionEqualityComparer)),
 					Arg.Any<IProject>(), IdeaRS.OpenModel.CountryCode.ECEN);
 		}

--- a/src/IdeaStatiCa.BimImporter/BimImporter.cs
+++ b/src/IdeaStatiCa.BimImporter/BimImporter.cs
@@ -236,6 +236,32 @@ namespace IdeaStatiCa.BimImporter
 			return CreateModelBIM(objects, bimItems, countryCode);
 		}
 
+		/// <inheritdoc cref="IBimImporter.ImportSubstructure"/>
+		/// <exception cref="ArgumentNullException">Throws when argument is null.</exception>
+		public ModelBIM ImportSubstructure(IEnumerable<IIdeaMember1D> members, CountryCode countryCode)
+		{
+			if (members is null)
+			{
+				throw new ArgumentNullException(nameof(members));
+			}
+
+			_remoteApp?.SendMessageLocalised(MessageSeverity.Info, LocalisedMessage.ImportingMembers);
+
+			List<IIdeaMember1D> importedMembers = members.Where(x => x != null).ToList();
+
+			// Map the members up front so they hold the model's leading IOM ids. The import maps a member only
+			// after the geometry it references, which would otherwise scatter them through the numbering.
+			foreach (IIdeaMember1D member in importedMembers)
+			{
+				_project.GetIomId(member);
+			}
+
+			return CreateModelBIM(
+				Enumerable.Empty<IIdeaObject>(),
+				importedMembers.Select(x => new Member(x)),
+				countryCode);
+		}
+
 		/// <inheritdoc cref="IBimImporter.ImportSelected"/>
 		/// <exception cref="InvalidOperationException">Throws if <see cref="IIdeaModel.GetSingleSelection"/> returns null arguments.</exception>
 		public List<ModelBIM> ImportSelected(List<BIMItemsGroup> selected, CountryCode countryCode)

--- a/src/IdeaStatiCa.BimImporter/IBimImporter.cs
+++ b/src/IdeaStatiCa.BimImporter/IBimImporter.cs
@@ -50,7 +50,27 @@ namespace IdeaStatiCa.BimImporter
 		ModelBIM ImportMembers(CountryCode countryCode);
 
 		/// <summary>
-		/// Reimports previously imported objects. 
+		/// Imports the given members into IOM. Reads no selection from the model and adds none of the members
+		/// framing into their end nodes, so the result holds exactly the members passed in.
+		/// </summary>
+		/// <remarks>
+		/// For a caller that already holds the members: they are read from the BIM application once.
+		/// <see cref="ImportSelected"/> addresses items by IOM id and resolves each one back into an object,
+		/// which reads every entity a second time.
+		/// <para>
+		/// The members are given the model's leading IOM ids, ahead of the geometry they reference. A member
+		/// that is null is skipped, which is what an unresolvable entity arrives as. Details are not supported
+		/// here — a <see cref="RequestedItemsType.Substructure"/> group can also carry them, this cannot.
+		/// </para>
+		/// </remarks>
+		/// <param name="members">Members to import.</param>
+		/// <param name="countryCode"></param>
+		/// <returns>ModelBIM object.</returns>
+		/// <exception cref="System.ArgumentNullException">Throws when <paramref name="members"/> is null.</exception>
+		ModelBIM ImportSubstructure(IEnumerable<IIdeaMember1D> members, CountryCode countryCode);
+
+		/// <summary>
+		/// Reimports previously imported objects.
 		/// </summary>
 		/// <param name="selected">List of objects to reimport.</param>
 		/// <param name="countryCode"></param>


### PR DESCRIPTION
`ImportSelected` addresses items by IOM id, so it resolves every id back into an object through
`IProject.GetBimObject` — a second read from the BIM application for a caller that already holds
the objects. `ImportSubstructure` takes the members directly, so they are read once.

It also maps the members before importing them, so they hold the model's leading IOM ids.
`ImportContext` maps a member only after the geometry it references, so without this every entity
in the exported model lands on a different id (measured: 234 of 234 moved).

Additive — no existing entry point changes behaviour. Its only caller is the Model Coordinator
pull in the main repo, where it takes reads per member from 2 to 1 (SAP2000, 62 members).

**Note for reviewers:** adding a member to the public `IBimImporter` is a compile-time break for
any third party implementing that interface. `netstandard2.0`, so no default interface member is
available. In-repo `BimImporter` is the only implementer.

Tests verified red against a deliberate id round-trip implementation, green against this one, on
net48 and net10.0. Suite: 120/120.

AI-assisted PR - human review required