### PR TITLE
#36925 Fail when the service answers 2xx with a body this client cannot read, instead of returning null

### DIFF
--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiClient.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiClient.cs
@@ -154,6 +154,22 @@ namespace IdeaStatiCa.ConnectionApi
 			this.ConnectionLibrary = new ConnectionLibraryApiExt(clientApi.Client, clientApi.AsynchronousClient, configuration);
 
 			this.ClientApi = clientApi;
+
+			// Every API reports a response this client cannot read instead of returning null - see
+			// IdeaApiExceptionFactory. Assigned after construction, because each generated constructor
+			// sets Configuration.DefaultExceptionFactory on itself, and there is no configuration
+			// property to carry it.
+			foreach (IApiAccessor api in new IApiAccessor[]
+			{
+				clientApi, this.Calculation, this.CalculationJobs, this.Connection, this.Export,
+				this.LoadEffect, this.Material, this.Member, this.Operation, this.Parameter,
+				this.Presentation, this.Project, this.Report, this.Template, this.Conversion,
+				this.Settings, this.ConnectionLibrary,
+			})
+			{
+				api.ExceptionFactory = IdeaApiExceptionFactory.Instance;
+			}
+
 			return ClientId;
 		}
 

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/IdeaApiExceptionFactory.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/IdeaApiExceptionFactory.cs
@@ -1,0 +1,99 @@
+using IdeaStatiCa.ConnectionApi.Client;
+using System;
+
+namespace IdeaStatiCa.ConnectionApi
+{
+	/// <summary>
+	/// The <see cref="ExceptionFactory"/> every API of <see cref="ConnectionApiClient"/> is wired to.
+	///
+	/// It keeps the generated behaviour for a failed request - <see cref="Configuration.DefaultExceptionFactory"/>
+	/// raises for HTTP status 400 and above, and for a transport failure reported as status 0 - and adds
+	/// the case that behaviour misses: a SUCCESSFUL status whose body this client cannot read.
+	///
+	/// How that happens: the response body is converted by the client's own deserializer, and RestSharp
+	/// catches whatever the deserializer throws instead of letting it out - it lands in the response's
+	/// error message. The generated code copies that into <see cref="IApiResponse.ErrorText"/>, but the
+	/// default factory only looks at the status code, so the call returns <c>null</c> and throws nothing.
+	/// The caller then cannot tell "the service has no data for this" from "this client cannot read what
+	/// the service sent", which is the difference between an empty model and a version mismatch.
+	///
+	/// Measured against a 26.1 service with a 26.0 client:
+	/// <c>export-iom-connection-data</c> answers HTTP 200 with 296 218 characters of JSON that the client
+	/// cannot deserialise (<c>beams[0].plates[0].material</c> is an object where this client's IdeaRS.OpenModel
+	/// expects a scalar). The call returned <c>null</c>, the example built on it concluded the joint's brace
+	/// feet overlapped - a statement about geometry drawn from the absence of geometry - and no diagnostic
+	/// anywhere named the real cause.
+	/// </summary>
+	public static class IdeaApiExceptionFactory
+	{
+		/// <summary>
+		/// Assign to <see cref="IApiAccessor.ExceptionFactory"/>. Stateless and safe to share.
+		/// </summary>
+		public static readonly ExceptionFactory Instance = (methodName, response) =>
+		{
+			// A failed request is the generated factory's business, and its messages are the ones
+			// callers already handle. Only what it lets through is reconsidered below.
+			Exception generated = Configuration.DefaultExceptionFactory(methodName, response);
+			if (generated != null)
+			{
+				return generated;
+			}
+
+			return UnreadableBody(methodName, response);
+		};
+
+		/// <summary>
+		/// An <see cref="ApiException"/> when a 2xx response carries a body that did not become an
+		/// object, or null when there is nothing wrong.
+		///
+		/// Deliberately narrow - this must never turn a working call into an exception:
+		///
+		///   - only 2xx, because everything else is already handled;
+		///   - only when the deserialised value is null AND the body is not itself empty or the JSON
+		///     literal <c>null</c>, which are legitimate answers ("no template applied", "no results yet");
+		///   - only for a response type that CAN be null, so an endpoint returning a number or a bool is
+		///     out of scope. Those cannot be told apart: a body that fails to convert leaves the default
+		///     value (0, false), which is indistinguishable from a real one. Callers of those endpoints
+		///     still depend on the service answering sensibly - fixing that needs the generated
+		///     conversion to stop swallowing, which is not something this hook can reach.
+		/// </summary>
+		private static ApiException UnreadableBody(string methodName, IApiResponse response)
+		{
+			int status = (int)response.StatusCode;
+			if (status < 200 || status > 299)
+			{
+				return null;
+			}
+
+			if (response.Content != null)
+			{
+				return null;
+			}
+
+			Type type = response.ResponseType;
+			if (type == null || (type.IsValueType && Nullable.GetUnderlyingType(type) == null))
+			{
+				return null;
+			}
+
+			string raw = response.RawContent;
+			if (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "null")
+			{
+				return null;
+			}
+
+			// The reason, when the deserializer left one. Without it the length of the body is still
+			// worth reporting: it is what distinguishes this from an empty answer.
+			string reason = string.IsNullOrWhiteSpace(response.ErrorText)
+				? $"the body is {raw.Length} characters long and no reason was reported"
+				: response.ErrorText.Trim();
+
+			return new ApiException(500,
+				$"Error calling {methodName}: the service answered {status} but this client could not read"
+				+ $" the response into {type.Name} ({reason}). This is usually a version mismatch - a"
+				+ " service newer than the client package. Check the service version against the"
+				+ " IdeaStatiCa.ConnectionApi version in use.",
+				raw, response.Headers);
+		}
+	}
+}

--- a/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/IdeaApiExceptionFactoryTests.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/IdeaApiExceptionFactoryTests.cs
@@ -1,0 +1,122 @@
+using IdeaStatiCa.ConnectionApi;
+using IdeaStatiCa.ConnectionApi.Client;
+using System.Net;
+
+namespace ST_ConRestApiClient
+{
+	/// <summary>
+	/// The exception factory every API of <see cref="ConnectionApiClient"/> is wired to. Offline: it
+	/// decides from a response object alone, so no service is needed to pin what it does and - more
+	/// importantly - what it leaves alone.
+	/// </summary>
+	[TestFixture]
+	public class IdeaApiExceptionFactoryTests
+	{
+		private const string SomeJson = "{\"beams\":[{\"plates\":[{\"material\":{\"id\":1}}]}]}";
+
+		/// <summary>A response whose body did not become an object - the case under test.</summary>
+		private static ApiResponse<T> Unread<T>(HttpStatusCode status, string rawContent,
+			string? errorText = null) where T : class
+			=> new ApiResponse<T>(status, new Multimap<string, string>(), default!, rawContent)
+			{
+				ErrorText = errorText,
+			};
+
+		/// <summary>A response that read into a value - nothing for the factory to report.</summary>
+		private static ApiResponse<T> Read<T>(HttpStatusCode status, T data, string rawContent)
+			=> new ApiResponse<T>(status, new Multimap<string, string>(), data, rawContent);
+
+		[Test]
+		public void SuccessWithABodyThatDidNotDeserialise_Throws()
+		{
+			// what a 26.0 client gets from a 26.1 service on export-iom-connection-data
+			var response = Unread<object>(HttpStatusCode.OK, SomeJson,
+				"Unexpected character encountered while parsing value: {. Path 'beams[0].plates[0].material'");
+
+			var exception = IdeaApiExceptionFactory.Instance("ExportIomConnectionData", response);
+
+			Assert.That(exception, Is.InstanceOf<ApiException>());
+			Assert.Multiple(() =>
+			{
+				// the method, the reason the deserializer gave, and the direction to look in
+				Assert.That(exception!.Message, Does.Contain("ExportIomConnectionData"));
+				Assert.That(exception.Message, Does.Contain("beams[0].plates[0].material"));
+				Assert.That(exception.Message, Does.Contain("version mismatch"));
+				// the body is kept, so a caller that logs the exception can see what arrived
+				Assert.That(((ApiException)exception).ErrorContent, Is.EqualTo(SomeJson));
+			});
+		}
+
+		[Test]
+		public void SuccessWithABodyThatDidNotDeserialise_AndNoReasonReported_StillThrows()
+		{
+			var response = Unread<object>(HttpStatusCode.OK, SomeJson);
+
+			var exception = IdeaApiExceptionFactory.Instance("ExportIomConnectionData", response);
+
+			Assert.That(exception, Is.InstanceOf<ApiException>());
+			// the length is what separates this from an empty answer
+			Assert.That(exception!.Message, Does.Contain($"{SomeJson.Length} characters"));
+		}
+
+		/// <summary>
+		/// The legitimate nulls. Each of these is an answer, not a failure, and turning any of them
+		/// into an exception would break working code - which is the risk this hook carries.
+		/// </summary>
+		[Test]
+		public void SuccessWithNothingToRead_DoesNotThrow()
+		{
+			Assert.Multiple(() =>
+			{
+				Assert.That(IdeaApiExceptionFactory.Instance("GetTemplate",
+					Unread<object>(HttpStatusCode.OK, "null")), Is.Null, "the JSON literal null");
+
+				Assert.That(IdeaApiExceptionFactory.Instance("GetTemplate",
+					Unread<object>(HttpStatusCode.OK, "")), Is.Null, "an empty body");
+
+				Assert.That(IdeaApiExceptionFactory.Instance("GetTemplate",
+					Unread<object>(HttpStatusCode.OK, "   ")), Is.Null, "whitespace only");
+
+				Assert.That(IdeaApiExceptionFactory.Instance("DeleteMember",
+					Unread<object>(HttpStatusCode.NoContent, "")), Is.Null, "204 No Content");
+
+				Assert.That(IdeaApiExceptionFactory.Instance("GetConnection",
+					Read(HttpStatusCode.OK, "read fine", SomeJson)), Is.Null, "a body that read");
+			});
+		}
+
+		/// <summary>
+		/// A response typed as a non-nullable value type cannot be judged: a body that fails to convert
+		/// leaves 0 or false, which is indistinguishable from a real answer. Documented here so the
+		/// limitation is a decision rather than an oversight.
+		/// </summary>
+		[Test]
+		public void SuccessWithAValueTypeResponse_IsOutOfScope()
+		{
+			Assert.That(IdeaApiExceptionFactory.Instance("GetCount",
+				Read(HttpStatusCode.OK, 0, SomeJson)), Is.Null);
+		}
+
+		[Test]
+		public void FailedRequests_KeepTheGeneratedBehaviour()
+		{
+			var notFound = Unread<object>(HttpStatusCode.NotFound, "{\"title\":\"Not Found\"}");
+			var transportFailure = Unread<object>((HttpStatusCode)0, "", "no connection");
+
+			var fromNotFound = IdeaApiExceptionFactory.Instance("GetConnection", notFound);
+			var fromTransport = IdeaApiExceptionFactory.Instance("GetConnection", transportFailure);
+
+			Assert.Multiple(() =>
+			{
+				// the generated factory's own message, unchanged: callers already handle these
+				Assert.That(fromNotFound, Is.InstanceOf<ApiException>());
+				Assert.That(((ApiException)fromNotFound!).ErrorCode, Is.EqualTo(404));
+				Assert.That(fromNotFound.Message, Does.Contain("Not Found"));
+
+				Assert.That(fromTransport, Is.InstanceOf<ApiException>());
+				Assert.That(((ApiException)fromTransport!).ErrorCode, Is.EqualTo(0));
+				Assert.That(fromTransport.Message, Does.Contain("no connection"));
+			});
+		}
+	}
+}


### PR DESCRIPTION
The response body is converted by the client's own deserializer, and RestSharp catches whatever that throws instead of letting it out - it ends up in the response's error message, which the generated code copies into `ApiResponse.ErrorText`. `Configuration.DefaultExceptionFactory` only looks at the status code (>= 400, or 0 for a transport failure), so nothing reads it: **the call returns `null` and throws nothing.** The caller cannot tell "the service has no data for this" from "this client cannot read what the service sent".

Measured - published client 26.0.4.1707 and these sources alike - against a 26.1 service: `export-iom-connection-data` answers HTTP 200 with 296 218 characters of JSON, the client returns null, nothing is logged. The NorsokChecker example built on that null concluded that a joint's brace feet overlapped - a statement about geometry drawn from the absence of geometry - and pinned itself to a 26.0 service to avoid it. The payload incompatibility itself is a separate work item (#36926); this is why nobody could see it.

`IdeaApiExceptionFactory` delegates to the generated factory first, so every failed request keeps the message callers already handle, and adds the case it misses. Deliberately narrow, because this must never turn a working call into an exception: 2xx only, deserialised value null, body neither empty nor the JSON literal `null`, and a response type that can be null at all. A response typed as a non-nullable value type is out of scope and a test says so.

Wired in `ConnectionApiClient` for all 17 APIs after construction: each generated constructor assigns `Configuration.DefaultExceptionFactory` to itself and there is no configuration property to carry it. **Both files that hold the fix are hand-written, so a client regeneration does not take it away** - `Client/ApiClient.cs` and `Client/Configuration.cs` are in `.openapi-generator/FILES` and were not touched.

**Verified:** 5 offline tests over the response shapes; against a live 26.1 service the same call now throws *"the service answered 200 but this client could not read the response into ConnectionData (Unexpected character ... Path 'beams[0].plates[0].material') ... usually a version mismatch"*; against 26.0, all 15 connections of the same probe still read their model.

Work item #36925. Found during the NorsokChecker software review.

AI-assisted PR - human review required