### PR TITLE
#36928 ConnectionApiServiceRunner owns the service it starts: kill-on-close, and a locator to find one

### DIFF
--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceLocator.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceLocator.cs
@@ -1,0 +1,235 @@
+using IdeaStatiCa.Api.Connection;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdeaStatiCa.ConnectionApi
+{
+	/// <summary>
+	/// One installation of the Connection REST API service found on this machine.
+	/// </summary>
+	public sealed class ConnectionApiServiceInstallation
+	{
+		internal ConnectionApiServiceInstallation(string directory, string executablePath, Version version)
+		{
+			Directory = directory;
+			ExecutablePath = executablePath;
+			Version = version;
+		}
+
+		/// <summary>The directory to hand to <see cref="ConnectionApiServiceRunner"/>.</summary>
+		public string Directory { get; }
+
+		/// <summary>Full path of the service executable inside <see cref="Directory"/>.</summary>
+		public string ExecutablePath { get; }
+
+		/// <summary>
+		/// The version of the executable itself, read from its file version - the build included, which
+		/// is what a folder name cannot tell. <c>0.0</c> when it could not be read.
+		/// </summary>
+		public Version Version { get; }
+
+		/// <inheritdoc/>
+		public override string ToString() => $"{Version} ({Directory})";
+	}
+
+	/// <summary>
+	/// Finds the Connection REST API service on this machine, and asks a running one which version it is.
+	///
+	/// <see cref="ConnectionApiServiceRunner"/> needs a directory and offers nothing to compute one, so
+	/// every application that spawns a service has had to answer these two questions for itself:
+	///
+	///   - WHICH service to start. Hard-coding a path breaks on a machine with a different version
+	///     installed, and the failure surfaces late: a service too old for the endpoints in use answers
+	///     404, and one too new can answer everything while returning a model the client cannot read.
+	///   - WHETHER to start one at all. A service HOLDS AN IDEA StatiCa LICENCE SEAT while it runs, so
+	///     attaching to one that is already listening costs nothing where starting a second one costs a
+	///     seat.
+	///
+	/// Choosing between installations is left to the caller: which versions an application can work with
+	/// is a property of the application, not of the machine.
+	/// </summary>
+	public static class ConnectionApiServiceLocator
+	{
+		/// <summary>Name of the service executable.</summary>
+		public const string ExecutableName = "IdeaStatiCa.ConnectionRestApi.exe";
+
+		/// <summary>
+		/// A full path to a service executable in this environment variable overrides everything the
+		/// search below would find - the escape hatch for a portable copy or a build laid down by hand.
+		/// </summary>
+		public const string ExecutableOverrideVariable = "IDEA_CONNECTION_REST_EXE";
+
+		/// <summary>The port a service that nobody configured listens on.</summary>
+		public const int DefaultPort = 5000;
+
+		private const string VersionEndpoint = "api/4/" + ConRestApiConstants.Client + "/idea-service-version";
+
+		/// <summary>
+		/// Every installation the search finds, newest first.
+		///
+		/// Where it looks: the executable named by <see cref="ExecutableOverrideVariable"/>, then
+		/// <paramref name="root"/> or - when that is null - the conventional roots
+		/// (<c>%ProgramFiles%\IDEA StatiCa</c> and its 64-bit form), both as a directory that may itself
+		/// hold the executable and as a parent of the per-version directories. Both shapes occur: a full
+		/// installation ("StatiCa 26.0") and the service on its own ("Connection API 26.1").
+		///
+		/// The registry is deliberately not read. It would find an installation outside these roots, but
+		/// it would also make this package depend on Microsoft.Win32.Registry for a netstandard target -
+		/// and its other advantage, the build number, is available here from the executable itself.
+		/// An installation in an unconventional place is what the override variable and
+		/// <paramref name="root"/> are for.
+		/// </summary>
+		/// <param name="root">A directory to search instead of the conventional roots. Optional.</param>
+		public static IReadOnlyList<ConnectionApiServiceInstallation> FindInstallations(string root = null)
+		{
+			var found = new List<ConnectionApiServiceInstallation>();
+			var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+			string overridden = Environment.GetEnvironmentVariable(ExecutableOverrideVariable);
+			if (!string.IsNullOrWhiteSpace(overridden) && File.Exists(overridden))
+			{
+				Add(Path.GetDirectoryName(overridden));
+			}
+
+			foreach (string searchRoot in Roots(root))
+			{
+				Add(searchRoot);                     // the root may itself be an installation
+				try
+				{
+					foreach (string directory in Directory.GetDirectories(searchRoot))
+					{
+						Add(directory);
+					}
+				}
+				catch (Exception)
+				{
+					// a root that does not exist or cannot be listed is simply not a source
+				}
+			}
+
+			return found.OrderByDescending(i => i.Version).ToList();
+
+			void Add(string directory)
+			{
+				if (string.IsNullOrWhiteSpace(directory))
+				{
+					return;
+				}
+
+				string executable = Path.Combine(directory, ExecutableName);
+				if (!File.Exists(executable) || !seen.Add(executable))
+				{
+					return;
+				}
+
+				found.Add(new ConnectionApiServiceInstallation(directory, executable, VersionOf(executable)));
+			}
+		}
+
+		/// <summary>
+		/// Whether a directory holds the service executable, i.e. whether it can be handed to
+		/// <see cref="ConnectionApiServiceRunner"/>.
+		/// </summary>
+		public static bool IsServiceInstallation(string directory)
+			=> !string.IsNullOrWhiteSpace(directory)
+				&& File.Exists(Path.Combine(directory, ExecutableName));
+
+		/// <summary>
+		/// The version a service listening at this base URL reports, or null when nothing answers there
+		/// or what answers is not this service. Never throws - "is one running" and "which one" are the
+		/// same question.
+		/// </summary>
+		/// <param name="baseUrl">For example <c>http://localhost:5000</c>.</param>
+		/// <param name="timeout">How long to wait. Defaults to three seconds.</param>
+		/// <param name="cancellationToken">Token to cancel the probe.</param>
+		public static async Task<string> GetRunningServiceVersionAsync(string baseUrl,
+			TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+		{
+			if (string.IsNullOrWhiteSpace(baseUrl))
+			{
+				return null;
+			}
+
+			try
+			{
+				using (var http = new HttpClient { Timeout = timeout ?? TimeSpan.FromSeconds(3) })
+				{
+					var response = await http
+						.GetAsync($"{baseUrl.TrimEnd('/')}/{VersionEndpoint}", cancellationToken)
+						.ConfigureAwait(false);
+					if (!response.IsSuccessStatusCode)
+					{
+						return null;
+					}
+
+					// the endpoint answers a bare JSON string
+					string version = (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+						.Trim().Trim('"');
+					return string.IsNullOrWhiteSpace(version) ? null : version;
+				}
+			}
+			catch (Exception)
+			{
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// The version of a service already listening on <see cref="DefaultPort"/>, or null.
+		///
+		/// Worth asking before starting one: a service that is already running can be used through
+		/// <see cref="ConnectionApiServiceAttacher"/>, and starting another takes a second licence seat.
+		/// </summary>
+		public static Task<string> GetRunningServiceVersionOnDefaultPortAsync(
+			CancellationToken cancellationToken = default)
+			=> GetRunningServiceVersionAsync($"http://localhost:{DefaultPort}",
+				cancellationToken: cancellationToken);
+
+		private static IEnumerable<string> Roots(string root)
+		{
+			if (!string.IsNullOrWhiteSpace(root))
+			{
+				yield return root;
+				yield break;
+			}
+
+			// ProgramW6432 is the 64-bit Program Files whatever the bitness of this process; ProgramFiles
+			// is the same directory for a 64-bit process and the x86 one for a 32-bit process, so both
+			// are searched and the duplicate is dropped by the executable path.
+			foreach (string variable in new[] { "ProgramW6432", "ProgramFiles" })
+			{
+				string programFiles = Environment.GetEnvironmentVariable(variable);
+				if (!string.IsNullOrWhiteSpace(programFiles))
+				{
+					yield return Path.Combine(programFiles, "IDEA StatiCa");
+				}
+			}
+		}
+
+		private static Version VersionOf(string executablePath)
+		{
+			try
+			{
+				var info = FileVersionInfo.GetVersionInfo(executablePath);
+				if (Version.TryParse(info.FileVersion, out Version version))
+				{
+					return version;
+				}
+
+				return new Version(info.FileMajorPart, info.FileMinorPart, info.FileBuildPart,
+					info.FilePrivatePart);
+			}
+			catch (Exception)
+			{
+				// an executable whose version cannot be read is still an executable
+				return new Version(0, 0);
+			}
+		}
+	}
+}

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceRunner.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceRunner.cs
@@ -20,15 +20,59 @@ namespace IdeaStatiCa.ConnectionApi
 		private Process serviceProcess;
 		private string launchPath;
 		private int port = -1;
+		private readonly Action<string> log;
+		private ServiceJobObject job;
 
 		/// <summary>
 		/// Constructor
 		/// </summary>
 		/// <param name="setupDir"> where .exe file is located</param>
-		public ConnectionApiServiceRunner(string setupDir)
+		public ConnectionApiServiceRunner(string setupDir) : this(setupDir, null)
+		{
+		}
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="setupDir">where .exe file is located</param>
+		/// <param name="log">
+		/// Receives what happens around the service process itself - which executable was started, and
+		/// anything that weakens the guarantee that the service is shut down with this process (see
+		/// <see cref="IsServiceOwned"/>). Optional; pass null to keep it silent.
+		/// </param>
+		public ConnectionApiServiceRunner(string setupDir, Action<string> log)
 		{
 			launchPath = setupDir;
+			this.log = log ?? (_ => { });
 		}
+
+		/// <summary>
+		/// Process id of the service this runner started, or null when it has not started one.
+		/// </summary>
+		public int? ServiceProcessId
+		{
+			get
+			{
+				try
+				{
+					return serviceProcess != null && !serviceProcess.HasExited ? serviceProcess.Id : (int?)null;
+				}
+				catch (InvalidOperationException)
+				{
+					return null;      // the process was never started, or has already been disposed
+				}
+			}
+		}
+
+		/// <summary>
+		/// Whether the service is guaranteed to be shut down when THIS process ends, however it ends -
+		/// including a hard kill or a crash, which no managed cleanup survives.
+		///
+		/// It matters because a running service holds an IDEA StatiCa licence seat: a service left behind
+		/// costs the user that seat until the process is found and ended. False means only an orderly
+		/// <see cref="Dispose"/> shuts it down; the log callback passed to the constructor says why.
+		/// </summary>
+		public bool IsServiceOwned => job != null && job.IsActive;
 
 		/// <inheritdoc cref="IApiServiceFactory{T}.CreateApiClient"/>
 		public async Task<IConnectionApiClient> CreateApiClient()
@@ -69,6 +113,15 @@ namespace IdeaStatiCa.ConnectionApi
 						{
 							throw new InvalidOperationException($"Failed to start the process. {apiExecutablePath}");
 						}
+
+						// Own it before waiting for the heartbeat: the service is already running, so from
+						// here on a crash of this process could leak it - and a service that outlives its
+						// client keeps an IDEA StatiCa licence seat. See ServiceJobObject.
+						job = job ?? new ServiceJobObject(log);
+						job.Adopt(serviceProcess);
+						log($"Connection API service started from '{apiExecutablePath}' on port {port}"
+							+ $" (pid {serviceProcess.Id}); it is shut down with this process"
+							+ (IsServiceOwned ? ", even if this process is killed." : " only on an orderly exit."));
 
 						// Wait for the API to start (you might need a more robust way to determine this)
 						var apiUrlBase = new Uri($"{LOCALHOST_URL}:{port}");
@@ -112,10 +165,33 @@ namespace IdeaStatiCa.ConnectionApi
 		{
 			if (serviceProcess != null)
 			{
-				serviceProcess.Kill();
+				try
+				{
+					// A service that has already exited on its own is not an error here, and Kill throws
+					// for one - which used to make disposing a runner whose service had crashed throw
+					// instead of cleaning up.
+					if (!serviceProcess.HasExited)
+					{
+						serviceProcess.Kill();
+					}
+				}
+				catch (Exception e)
+				{
+					log($"The Connection API service (pid {ServiceProcessId}) could not be ended"
+						+ $" ({e.Message}); the Job Object takes it down with this process.");
+				}
+
 				serviceProcess.Dispose();
 				serviceProcess = null;
 			}
+
+			// Closing the job handle is what terminates anything still in it, so this comes last.
+			if (job != null)
+			{
+				job.Dispose();
+				job = null;
+			}
+
 			GC.SuppressFinalize(this);
 		}
 

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ServiceJobObject.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ServiceJobObject.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace IdeaStatiCa.ConnectionApi
+{
+	/// <summary>
+	/// Makes sure a service process started by <see cref="ConnectionApiServiceRunner"/> never outlives
+	/// the process that started it.
+	///
+	/// Why it matters: a running Connection REST API service HOLDS AN IDEA StatiCa LICENCE SEAT. A
+	/// service that is left behind costs the user that seat until someone finds the process and ends it,
+	/// and the loss compounds - the runner takes a free port for every service it starts, so the next
+	/// run does not notice the orphan and starts another beside it.
+	///
+	/// <see cref="ConnectionApiServiceRunner.Dispose"/> covers an orderly exit. It does NOT cover a hard
+	/// kill of the calling process, a crash, or a power loss: no managed code runs then. A Windows Job
+	/// Object does, because WINDOWS does the killing - with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE every
+	/// process in the job is terminated when the last handle to the job closes, and that happens however
+	/// the owning process goes away.
+	///
+	/// Best-effort throughout: this is a safety net, and failing to set it up must never stop a service
+	/// from being used. Every failure is reported through the runner's log callback and swallowed, and
+	/// <see cref="IsActive"/> says whether the guarantee actually holds.
+	/// </summary>
+	internal sealed class ServiceJobObject : IDisposable
+	{
+		private readonly Action<string> _log;
+		private IntPtr _job = IntPtr.Zero;
+
+		internal ServiceJobObject(Action<string> log)
+		{
+			_log = log ?? (_ => { });
+
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				// The service is a Windows executable, so this is not a case that arises today - but the
+				// package targets netstandard and the P/Invoke below would throw on anything else.
+				return;
+			}
+
+			try
+			{
+				_job = CreateJobObject(IntPtr.Zero, null);
+				if (_job == IntPtr.Zero)
+				{
+					_log("The Connection API service could not be put under a Job Object: a hard kill of"
+						+ " this process would leave the service running and holding a licence seat.");
+					return;
+				}
+
+				var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+				{
+					BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+					{
+						LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+					},
+				};
+
+				int size = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+				IntPtr buffer = Marshal.AllocHGlobal(size);
+				try
+				{
+					Marshal.StructureToPtr(info, buffer, false);
+					if (!SetInformationJobObject(_job, JobObjectExtendedLimitInformation, buffer, (uint)size))
+					{
+						_log("The Job Object rejected KILL_ON_JOB_CLOSE: the Connection API service is"
+							+ " only shut down on an orderly exit.");
+						Close();
+					}
+				}
+				finally
+				{
+					Marshal.FreeHGlobal(buffer);
+				}
+			}
+			catch (Exception e)
+			{
+				_log($"The Connection API service could not be put under a Job Object ({e.Message}):"
+					+ " it is only shut down on an orderly exit.");
+				Close();
+			}
+		}
+
+		/// <summary>
+		/// Whether the job exists, i.e. whether adopted processes are actually guaranteed to be taken
+		/// down with this one.
+		/// </summary>
+		internal bool IsActive => _job != IntPtr.Zero;
+
+		/// <summary>
+		/// Put a process under the job. False means the guarantee does not hold for it and the orderly
+		/// path is the only cleanup - the caller should carry on, not fail.
+		/// </summary>
+		internal bool Adopt(Process process)
+		{
+			if (_job == IntPtr.Zero || process == null)
+			{
+				return false;
+			}
+
+			try
+			{
+				if (AssignProcessToJobObject(_job, process.Handle))
+				{
+					return true;
+				}
+
+				// 5 = ACCESS_DENIED, which is what a process already assigned to another job returns on
+				// Windows 7. Nested jobs work from Windows 8 on, so this is unlikely but real.
+				_log($"The Connection API service (pid {process.Id}) could not be assigned to the Job"
+					+ $" Object (Win32 error {Marshal.GetLastWin32Error()}): a hard kill of this process"
+					+ " would leave it running.");
+			}
+			catch (Exception e)
+			{
+				_log($"The Connection API service could not be assigned to the Job Object ({e.Message}).");
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Closing the handle is what terminates the job's processes, so this IS the cleanup - not a
+		/// release of something already cleaned up.
+		/// </summary>
+		public void Dispose() => Close();
+
+		private void Close()
+		{
+			if (_job == IntPtr.Zero)
+			{
+				return;
+			}
+
+			IntPtr job = _job;
+			_job = IntPtr.Zero;
+			CloseHandle(job);
+		}
+
+		private const int JobObjectExtendedLimitInformation = 9;
+		private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+		private static extern IntPtr CreateJobObject(IntPtr attributes, string name);
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		private static extern bool SetInformationJobObject(IntPtr job, int infoClass, IntPtr info,
+			uint infoLength);
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		private static extern bool CloseHandle(IntPtr handle);
+
+		[StructLayout(LayoutKind.Sequential)]
+		private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+		{
+			public long PerProcessUserTimeLimit;
+			public long PerJobUserTimeLimit;
+			public uint LimitFlags;
+			public UIntPtr MinimumWorkingSetSize;
+			public UIntPtr MaximumWorkingSetSize;
+			public uint ActiveProcessLimit;
+			public UIntPtr Affinity;
+			public uint PriorityClass;
+			public uint SchedulingClass;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		private struct IO_COUNTERS
+		{
+			public ulong ReadOperationCount, WriteOperationCount, OtherOperationCount;
+			public ulong ReadTransferCount, WriteTransferCount, OtherTransferCount;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+		{
+			public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+			public IO_COUNTERS IoInfo;
+			public UIntPtr ProcessMemoryLimit;
+			public UIntPtr JobMemoryLimit;
+			public UIntPtr PeakProcessMemoryUsed;
+			public UIntPtr PeakJobMemoryUsed;
+		}
+	}
+}

--- a/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ConnectionApiServiceLocatorTests.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ConnectionApiServiceLocatorTests.cs
@@ -1,0 +1,107 @@
+using IdeaStatiCa.ConnectionApi;
+
+namespace ST_ConRestApiClient
+{
+	/// <summary>
+	/// The service locator, against a synthetic installation tree rather than the machine's own - so the
+	/// test says the same thing on a build agent with no IDEA StatiCa installed as on a developer's
+	/// machine with four of them.
+	/// </summary>
+	[TestFixture]
+	public class ConnectionApiServiceLocatorTests
+	{
+		private string _root = null!;
+
+		[SetUp]
+		public void CreateInstallationTree()
+		{
+			_root = Path.Combine(Path.GetTempPath(), "ConApiLocatorTests", Guid.NewGuid().ToString("N"));
+
+			// the root as an installation itself (a portable copy), two versioned ones beside it, and a
+			// directory that is not an installation at all
+			Executable(_root);
+			Executable(Path.Combine(_root, "StatiCa 26.0"));
+			Executable(Path.Combine(_root, "Connection API 26.1"));
+			Directory.CreateDirectory(Path.Combine(_root, "Documentation"));
+		}
+
+		[TearDown]
+		public void RemoveInstallationTree()
+		{
+			try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+		}
+
+		private static void Executable(string directory)
+		{
+			Directory.CreateDirectory(directory);
+			File.WriteAllText(Path.Combine(directory, ConnectionApiServiceLocator.ExecutableName), "");
+		}
+
+		[Test]
+		public void FindInstallations_TakesTheRootAndItsSubdirectories()
+		{
+			var found = ConnectionApiServiceLocator.FindInstallations(_root);
+
+			Assert.That(found.Select(i => i.Directory), Is.EquivalentTo(new[]
+			{
+				_root,
+				Path.Combine(_root, "StatiCa 26.0"),
+				Path.Combine(_root, "Connection API 26.1"),
+			}), "a directory without the executable is not an installation");
+
+			Assert.That(found.Select(i => i.ExecutablePath),
+				Is.All.EndsWith(ConnectionApiServiceLocator.ExecutableName));
+		}
+
+		[Test]
+		public void FindInstallations_OfARootThatDoesNotExist_IsEmptyRatherThanAFailure()
+		{
+			Assert.That(
+				ConnectionApiServiceLocator.FindInstallations(Path.Combine(_root, "not installed here")),
+				Is.Empty);
+		}
+
+		[Test]
+		public void FindInstallations_ReadsTheVersionFromTheExecutable()
+		{
+			// these are empty files, so there is no version to read - and that must not drop them:
+			// an executable whose version cannot be read is still an executable
+			var found = ConnectionApiServiceLocator.FindInstallations(_root);
+
+			Assert.That(found, Is.Not.Empty);
+			Assert.That(found.Select(i => i.Version), Is.All.EqualTo(new Version(0, 0, 0, 0)));
+		}
+
+		[Test]
+		public void IsServiceInstallation_AsksForTheExecutable()
+		{
+			Assert.Multiple(() =>
+			{
+				Assert.That(ConnectionApiServiceLocator.IsServiceInstallation(_root), Is.True);
+				Assert.That(ConnectionApiServiceLocator.IsServiceInstallation(
+					Path.Combine(_root, "Documentation")), Is.False);
+				Assert.That(ConnectionApiServiceLocator.IsServiceInstallation(
+					Path.Combine(_root, "not installed here")), Is.False);
+				Assert.That(ConnectionApiServiceLocator.IsServiceInstallation(null), Is.False);
+				Assert.That(ConnectionApiServiceLocator.IsServiceInstallation(" "), Is.False);
+			});
+		}
+
+		[Test]
+		public async Task GetRunningServiceVersion_WhereNothingListens_IsNullRatherThanAFailure()
+		{
+			// port 1 needs privileges to bind and nothing serves HTTP there
+			string? version = await ConnectionApiServiceLocator.GetRunningServiceVersionAsync(
+				"http://localhost:1", TimeSpan.FromMilliseconds(500));
+
+			Assert.That(version, Is.Null);
+		}
+
+		[Test]
+		public async Task GetRunningServiceVersion_WithoutAUrl_IsNull()
+		{
+			Assert.That(await ConnectionApiServiceLocator.GetRunningServiceVersionAsync(null), Is.Null);
+			Assert.That(await ConnectionApiServiceLocator.GetRunningServiceVersionAsync("  "), Is.Null);
+		}
+	}
+}


### PR DESCRIPTION
**A running Connection REST API service holds an IDEA StatiCa licence seat.** `Dispose` covered an orderly exit and nothing else: a hard kill of the calling process, a crash or a power loss left the service running and the seat taken until someone found the process and ended it. The loss compounds, because the runner takes a free port for every service it starts, so the next run does not notice the orphan and starts another beside it.

**First commit - ownership.** A Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, assigned immediately after the process starts (before waiting for the heartbeat, which is already time in which a crash could leak it). Windows does the killing, so it survives what no managed cleanup does. Best-effort throughout: every failure is reported through a new optional log callback and swallowed, and `IsServiceOwned` says whether the guarantee holds. Also `ServiceProcessId` - without it, an application that wants that process has to guess which one it is, and the NorsokChecker example identifies it by image name and start time, which can adopt a second instance's service and kill it on exit - and `Dispose` no longer throws when the service has already exited on its own.

**Second commit - a locator.** The runner needs a setup directory and the SDK offered nothing to compute one, so every application answered the same two questions for itself: which service to start, and whether to start one at all rather than attach to a listening one and save a seat. `FindInstallations` searches `IDEA_CONNECTION_REST_EXE`, then the given root or `%ProgramFiles%\IDEA StatiCa`, each as an installation itself and as a parent of per-version directories; the version comes from the executable's own file version, so it carries the build. The registry is deliberately not read - it would add a `Microsoft.Win32.Registry` dependency for a netstandard target, and its other advantage, the build number, is available from the executable. Choosing between installations stays with the caller: which versions an application can work with is a property of the application, not of the machine.

**Verified:** a probe that starts a service and then hard-kills itself with `Process.Kill` leaves no service process behind (pid confirmed in tasklist before and after); the orderly path still ends it and no longer throws; the locator returns 26.1.0.3153, 26.1.0.25, 26.0.5.1419 and 25.1.5.1357 on a machine with four installs; 6 offline tests against a synthetic installation tree. Existing constructors and `CreateApiClient()` are unchanged.

Work item #36928. Found during the NorsokChecker software review - that example carries ~500 lines that exist only because the SDK does not do this.

AI-assisted PR - human review required