### PR TITLE
#36924 Let an application say what it is, so its API usage can be told apart from every other caller's

### DIFF
--- a/docs/docs/api/connection-api/connection_api_getting_started.md
+++ b/docs/docs/api/connection-api/connection_api_getting_started.md
@@ -59,7 +59,8 @@ Both clients provide a *service runner* that starts `IdeaStatiCa.ConnectionRestA
 ```csharp
 using IdeaStatiCa.ConnectionApi;
 
-using (var serviceRunner = new ConnectionApiServiceRunner(@"C:\Program Files\IDEA StatiCa\StatiCa 26.0"))
+using (var serviceRunner = new ConnectionApiServiceRunner(@"C:\Program Files\IDEA StatiCa\StatiCa 26.0",
+    "MyApplication", "1.0"))
 using (var client = await serviceRunner.CreateApiClient())
 {
     // use the client here
@@ -77,7 +78,7 @@ from ideastatica_connection_api.connection_api_service_runner import ConnectionA
 SETUP_DIR = r"C:\Program Files\IDEA StatiCa\StatiCa 26.0"
 
 async def main():
-    async with ConnectionApiServiceRunner(SETUP_DIR) as service_runner:
+    async with ConnectionApiServiceRunner(SETUP_DIR, "MyApplication", "1.0") as service_runner:
         with service_runner.create_api_client() as api_client:
             pass  # use the client here
 
@@ -111,7 +112,7 @@ With the service running you can open its Swagger UI in a browser at the root UR
 ```csharp
 using IdeaStatiCa.ConnectionApi;
 
-var attacher = new ConnectionApiServiceAttacher("http://localhost:5000");
+var attacher = new ConnectionApiServiceAttacher("http://localhost:5000", "MyApplication", "1.0");
 using (var client = await attacher.CreateApiClient())
 {
     // use the client here
@@ -123,7 +124,7 @@ using (var client = await attacher.CreateApiClient())
 ```python
 from ideastatica_connection_api.connection_api_service_attacher import ConnectionApiServiceAttacher
 
-attacher = ConnectionApiServiceAttacher("http://localhost:5000")
+attacher = ConnectionApiServiceAttacher("http://localhost:5000", "MyApplication", "1.0")
 with attacher.create_api_client() as api_client:
     pass  # use the client here
 ```
@@ -131,6 +132,14 @@ with attacher.create_api_client() as api_client:
 ---
 
 Attaching is convenient during development: you start the service once and run your script against it repeatedly without paying the service startup time.
+
+### Name your application
+
+Both factories take an optional application name and version, as in the snippets above. The name travels in a request header on every call the client makes, and the service reports its usage under it — which is how we can tell one integration apart from another and see which of them are actually used.
+
+Give the name of the application, not of the machine, the project or the person: it is meant to be a constant of your build. Keep it to printable ASCII and around 60 characters; anything longer is cut, and a name with a diacritic in it is refused by the service's HTTP stack before the request arrives.
+
+Passing nothing is fully supported and changes nothing — the calls are still served, just not attributed.
 
 ## Your first script
 

--- a/docs/docs/api/connection-api/connection_api_llm_reference.md
+++ b/docs/docs/api/connection-api/connection_api_llm_reference.md
@@ -89,10 +89,13 @@ internal class Program
     private static async Task Main()
     {
         // Option A: attach to a running service (start IdeaStatiCa.ConnectionRestApi.exe first)
-        var factory = new ConnectionApiServiceAttacher("http://localhost:5000");
+        // The application name and version are optional. They are reported with every call the
+        // service serves, which is what attributes usage to this integration rather than to the
+        // service itself. Printable ASCII, ~60 characters; omitting them changes nothing else.
+        var factory = new ConnectionApiServiceAttacher("http://localhost:5000", "MyApplication", "1.0");
 
         // Option B: start the service from the installation directory on a free port
-        // using var runner = new ConnectionApiServiceRunner(@"C:\Program Files\IDEA StatiCa\StatiCa 26.0");
+        // using var runner = new ConnectionApiServiceRunner(@"C:\Program Files\IDEA StatiCa\StatiCa 26.0", "MyApplication", "1.0");
         // IConnectionApiClient client = await runner.CreateApiClient();
 
         await using IConnectionApiClient client = await factory.CreateApiClient();
@@ -314,7 +317,7 @@ service_version = ClientApi(api_client.client).get_version()
 
 ## C# client surface
 
-`IConnectionApiClient` (created by `ConnectionApiServiceAttacher` or `ConnectionApiServiceRunner`, both returning a connected client from `CreateApiClient()`). Accessors: `ClientApi`, `Calculation`, `Connection`, `ConnectionLibrary`, `Conversion`, `Export`, `LoadEffect`, `Material`, `Member`, `Operation`, `Parameter`, `Presentation`, `Project`, `Report`, `Settings`, `Template`, plus `ActiveProjectId` and `ClientId` properties.
+`IConnectionApiClient` (created by `ConnectionApiServiceAttacher` or `ConnectionApiServiceRunner`, both returning a connected client from `CreateApiClient()`; both constructors take an optional application name and version that attribute every call this client makes — see the example above). Accessors: `ClientApi`, `Calculation`, `Connection`, `ConnectionLibrary`, `Conversion`, `Export`, `LoadEffect`, `Material`, `Member`, `Operation`, `Parameter`, `Presentation`, `Project`, `Report`, `Settings`, `Template`, plus `ActiveProjectId` and `ClientId` properties.
 
 Generated method names are the Python names in PascalCase with an `Async` suffix and `Guid projectId` instead of a string: `calculate` → `CalculateAsync(Guid projectId, List<int> requestBody)`, `get_connections` → `GetConnectionsAsync(Guid projectId)`, `update` → `UpdateAsync`, `get_settings` → `GetSettingsAsync`, and so on. The extension methods differ from Python in these places:
 

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ClientApplicationIdentity.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ClientApplicationIdentity.cs
@@ -61,10 +61,23 @@ namespace IdeaStatiCa.ConnectionApi
 			}
 
 			string suffix = Sanitize(version);
-			string value = suffix.Length == 0 ? name : $"{name}/{suffix}";
+			if (suffix.Length == 0)
+			{
+				return Truncate(name);
+			}
 
-			return value.Length <= MaxLength ? value : value.Substring(0, MaxLength);
+			// The name gives way before the version does. A version cut in half reads as a different
+			// version - which is worse than no version at all, since attributing by version is the
+			// point - so when even a whole version does not fit, it is dropped rather than trimmed.
+			int room = MaxLength - suffix.Length - 1;
+
+			return room < 1
+				? Truncate(name)
+				: $"{Truncate(name, room)}/{suffix}";
 		}
+
+		private static string Truncate(string value, int limit = MaxLength)
+			=> value.Length <= limit ? value : value.Substring(0, limit);
 
 		private static string Sanitize(string text)
 		{

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ClientApplicationIdentity.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ClientApplicationIdentity.cs
@@ -1,0 +1,80 @@
+using System.Text;
+
+namespace IdeaStatiCa.ConnectionApi
+{
+	/// <summary>
+	/// The name an application gives itself towards the Connection REST API service.
+	///
+	/// Why it exists: the service reports every endpoint call it serves, and without this every call
+	/// looks the same. It cannot tell a python script from a Grasshopper component from a partner's
+	/// desktop tool from one of our own examples, because the only thing a client is identified by is
+	/// the ClientId it was handed, which is a fresh GUID per session. So we cannot answer "which
+	/// integrations are actually used, and how" - and an application that wanted to be counted had to
+	/// report its own events through IdeaStatiCa.Diagnostics, which is not published outside the
+	/// company.
+	///
+	/// One string in a request header answers it for every client, whatever it is written in. Sending
+	/// nothing keeps the previous behaviour: the calls are counted, just not attributed.
+	///
+	/// It identifies the APPLICATION, not the user: it is meant to be a constant of the build, and
+	/// nothing about the machine, the project or the person belongs in it.
+	/// </summary>
+	public static class ClientApplicationIdentity
+	{
+		/// <summary>
+		/// The request header the service reads the identification from. A header rather than a
+		/// parameter of the connect call, so that identifying an application needs no change to any
+		/// endpoint, no regenerated client, and no version of the service newer than the one the
+		/// customer has - an older service simply ignores it.
+		/// </summary>
+		public const string HeaderName = "X-Idea-Client-App";
+
+		/// <summary>
+		/// The longest value that is sent. It is a name, not a payload, and it travels on every
+		/// request; anything longer is cut.
+		/// </summary>
+		public const int MaxLength = 64;
+
+		/// <summary>
+		/// The header value for an application name and an optional version, or null when there is
+		/// nothing to send.
+		///
+		/// The result is restricted to printable ASCII: a header value with a control character in it
+		/// is rejected outright by some HTTP stacks and quietly mangled by others, and a name is not
+		/// worth a failed request. Anything outside that range becomes '_', so the value stays
+		/// recognisable rather than disappearing.
+		/// </summary>
+		/// <param name="application">For example "NorsokChecker". Optional.</param>
+		/// <param name="version">For example "1.4.2". Optional.</param>
+		public static string Format(string application, string version = null)
+		{
+			string name = Sanitize(application);
+			if (name.Length == 0)
+			{
+				return null;
+			}
+
+			string suffix = Sanitize(version);
+			string value = suffix.Length == 0 ? name : $"{name}/{suffix}";
+
+			return value.Length <= MaxLength ? value : value.Substring(0, MaxLength);
+		}
+
+		private static string Sanitize(string text)
+		{
+			if (string.IsNullOrWhiteSpace(text))
+			{
+				return string.Empty;
+			}
+
+			var sanitized = new StringBuilder(text.Length);
+			foreach (char c in text.Trim())
+			{
+				// 0x20-0x7E is printable ASCII; the separator is reserved for joining name and version
+				sanitized.Append(c >= ' ' && c <= '~' && c != '/' ? c : '_');
+			}
+
+			return sanitized.ToString();
+		}
+	}
+}

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ClientApplicationIdentity.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ClientApplicationIdentity.cs
@@ -26,6 +26,11 @@ namespace IdeaStatiCa.ConnectionApi
 		/// parameter of the connect call, so that identifying an application needs no change to any
 		/// endpoint, no regenerated client, and no version of the service newer than the one the
 		/// customer has - an older service simply ignores it.
+		///
+		/// A caller that sets this header itself, without <see cref="Format"/>, has to keep the value
+		/// printable ASCII: a byte above 0x7F in a header value makes Kestrel answer the request with a
+		/// bare 400 before the service is reached, so a name with a diacritic in it fails every call
+		/// rather than arriving mangled.
 		/// </summary>
 		public const string HeaderName = "X-Idea-Client-App";
 
@@ -39,10 +44,11 @@ namespace IdeaStatiCa.ConnectionApi
 		/// The header value for an application name and an optional version, or null when there is
 		/// nothing to send.
 		///
-		/// The result is restricted to printable ASCII: a header value with a control character in it
-		/// is rejected outright by some HTTP stacks and quietly mangled by others, and a name is not
-		/// worth a failed request. Anything outside that range becomes '_', so the value stays
-		/// recognisable rather than disappearing.
+		/// The result is restricted to printable ASCII. A byte above 0x7F costs the whole request - the
+		/// service's HTTP stack answers a bare 400 before the service itself is reached - and a control
+		/// character below 0x20 has no business in a value that ends up in a log line. Anything outside
+		/// the range becomes '_', so a name never fails a call and stays recognisable rather than
+		/// disappearing.
 		/// </summary>
 		/// <param name="application">For example "NorsokChecker". Optional.</param>
 		/// <param name="version">For example "1.4.2". Optional.</param>

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiClient.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiClient.cs
@@ -77,12 +77,36 @@ namespace IdeaStatiCa.ConnectionApi
 		public string ClientId { get; private set; }
 
 		/// <summary>
-		/// 
+		/// The value sent in the <see cref="ClientApplicationIdentity.HeaderName"/> header, or null when
+		/// this client does not identify itself.
+		/// </summary>
+		private readonly string clientApplication;
+
+		/// <summary>
+		///
 		/// </summary>
 		/// <param name="basePath"></param>
-		public ConnectionApiClient(string basePath)
+		public ConnectionApiClient(string basePath) : this(basePath, null, null)
+		{
+		}
+
+		/// <summary>
+		/// Creates a client that identifies the calling application to the service.
+		/// </summary>
+		/// <param name="basePath">URL of the REST API service.</param>
+		/// <param name="clientApplication">
+		/// Name of the application making the calls, for example "NorsokChecker" - a constant of the
+		/// build, not anything about the machine, the project or the user. It is reported with every call
+		/// the service serves, which is what lets usage be attributed to an integration at all; see
+		/// <see cref="ClientApplicationIdentity"/>. Optional.
+		/// </param>
+		/// <param name="clientApplicationVersion">Version of that application. Optional.</param>
+		public ConnectionApiClient(string basePath, string clientApplication,
+			string clientApplicationVersion = null)
 		{
 			BasePath = new Uri(basePath);
+			this.clientApplication = ClientApplicationIdentity.Format(clientApplication,
+				clientApplicationVersion);
 		}
 
 		/// <summary>
@@ -131,6 +155,13 @@ namespace IdeaStatiCa.ConnectionApi
 			Configuration configuration = new Configuration();
 			configuration.Timeout = Timeout.Infinite;
 			configuration.BasePath = BasePath.AbsoluteUri;
+
+			// Set before the first call, so the service can attribute the connect itself. A service that
+			// does not know the header ignores it, so this is safe against any version.
+			if (clientApplication != null)
+			{
+				configuration.DefaultHeaders.Add(ClientApplicationIdentity.HeaderName, clientApplication);
+			}
 
 			var clientApi = new ClientApi(configuration);
 			ClientId = await clientApi.ConnectClientAsync();

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceAttacher.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceAttacher.cs
@@ -10,26 +10,30 @@ namespace IdeaStatiCa.ConnectionApi
 	{
 		string BaseUrl { get; set; }
 
+		private readonly string clientApplication;
+		private readonly string clientApplicationVersion;
+
 		/// <summary>
 		/// Constructor
 		/// </summary>
 		/// <param name="baseUrl"> URL of the REST API service</param>
-		public ConnectionApiServiceAttacher(string baseUrl)
+		/// <param name="clientApplication">
+		/// Name of the application making the calls, for example "NorsokChecker" - a constant of the
+		/// build, so it belongs to the factory rather than to a single call. Every client this factory
+		/// creates is reported under it, which is what lets usage be attributed to an integration at
+		/// all; see <see cref="ClientApplicationIdentity"/>. Optional.
+		/// </param>
+		/// <param name="clientApplicationVersion">Version of that application. Optional.</param>
+		public ConnectionApiServiceAttacher(string baseUrl, string clientApplication = null,
+			string clientApplicationVersion = null)
 		{
 			this.BaseUrl = baseUrl;
+			this.clientApplication = clientApplication;
+			this.clientApplicationVersion = clientApplicationVersion;
 		}
 
 		/// <inheritdoc cref="IApiServiceFactory{T}.CreateApiClient"/>
-		public Task<IConnectionApiClient> CreateApiClient() => CreateApiClient(null, null);
-
-		/// <summary>
-		/// Creates a client that identifies the calling application to the service, so its usage can be
-		/// told apart from every other caller's. See <see cref="ClientApplicationIdentity"/>.
-		/// </summary>
-		/// <param name="clientApplication">Name of the application making the calls.</param>
-		/// <param name="clientApplicationVersion">Version of that application. Optional.</param>
-		public async Task<IConnectionApiClient> CreateApiClient(string clientApplication,
-			string clientApplicationVersion = null)
+		public async Task<IConnectionApiClient> CreateApiClient()
 		{
 			var client = new ConnectionApiClient(BaseUrl, clientApplication, clientApplicationVersion);
 			await client.CreateAsync();

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceAttacher.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceAttacher.cs
@@ -20,9 +20,18 @@ namespace IdeaStatiCa.ConnectionApi
 		}
 
 		/// <inheritdoc cref="IApiServiceFactory{T}.CreateApiClient"/>
-		public async Task<IConnectionApiClient> CreateApiClient()
+		public Task<IConnectionApiClient> CreateApiClient() => CreateApiClient(null, null);
+
+		/// <summary>
+		/// Creates a client that identifies the calling application to the service, so its usage can be
+		/// told apart from every other caller's. See <see cref="ClientApplicationIdentity"/>.
+		/// </summary>
+		/// <param name="clientApplication">Name of the application making the calls.</param>
+		/// <param name="clientApplicationVersion">Version of that application. Optional.</param>
+		public async Task<IConnectionApiClient> CreateApiClient(string clientApplication,
+			string clientApplicationVersion = null)
 		{
-			var client = new ConnectionApiClient(BaseUrl);
+			var client = new ConnectionApiClient(BaseUrl, clientApplication, clientApplicationVersion);
 			await client.CreateAsync();
 			return client;
 		}

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceRunner.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceRunner.cs
@@ -20,28 +20,30 @@ namespace IdeaStatiCa.ConnectionApi
 		private Process serviceProcess;
 		private string launchPath;
 		private int port = -1;
+		private readonly string clientApplication;
+		private readonly string clientApplicationVersion;
 
 		/// <summary>
 		/// Constructor
 		/// </summary>
 		/// <param name="setupDir"> where .exe file is located</param>
-		public ConnectionApiServiceRunner(string setupDir)
+		/// <param name="clientApplication">
+		/// Name of the application making the calls, for example "NorsokChecker" - a constant of the
+		/// build, so it belongs to the factory rather than to a single call. Every client this factory
+		/// creates is reported under it, which is what lets usage be attributed to an integration at
+		/// all; see <see cref="ClientApplicationIdentity"/>. Optional.
+		/// </param>
+		/// <param name="clientApplicationVersion">Version of that application. Optional.</param>
+		public ConnectionApiServiceRunner(string setupDir, string clientApplication = null,
+			string clientApplicationVersion = null)
 		{
 			launchPath = setupDir;
+			this.clientApplication = clientApplication;
+			this.clientApplicationVersion = clientApplicationVersion;
 		}
 
 		/// <inheritdoc cref="IApiServiceFactory{T}.CreateApiClient"/>
-		public Task<IConnectionApiClient> CreateApiClient() => CreateApiClient(null, null);
-
-		/// <summary>
-		/// Starts the service if it is not running yet and creates a client that identifies the calling
-		/// application to it, so its usage can be told apart from every other caller's. See
-		/// <see cref="ClientApplicationIdentity"/>.
-		/// </summary>
-		/// <param name="clientApplication">Name of the application making the calls.</param>
-		/// <param name="clientApplicationVersion">Version of that application. Optional.</param>
-		public async Task<IConnectionApiClient> CreateApiClient(string clientApplication,
-			string clientApplicationVersion = null)
+		public async Task<IConnectionApiClient> CreateApiClient()
 		{
 			var url = await StartService();
 			var client = new ConnectionApiClient(url, clientApplication, clientApplicationVersion);

--- a/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceRunner.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/IdeaStatiCa.ConnectionApi/ConnectionApiServiceRunner.cs
@@ -31,10 +31,20 @@ namespace IdeaStatiCa.ConnectionApi
 		}
 
 		/// <inheritdoc cref="IApiServiceFactory{T}.CreateApiClient"/>
-		public async Task<IConnectionApiClient> CreateApiClient()
+		public Task<IConnectionApiClient> CreateApiClient() => CreateApiClient(null, null);
+
+		/// <summary>
+		/// Starts the service if it is not running yet and creates a client that identifies the calling
+		/// application to it, so its usage can be told apart from every other caller's. See
+		/// <see cref="ClientApplicationIdentity"/>.
+		/// </summary>
+		/// <param name="clientApplication">Name of the application making the calls.</param>
+		/// <param name="clientApplicationVersion">Version of that application. Optional.</param>
+		public async Task<IConnectionApiClient> CreateApiClient(string clientApplication,
+			string clientApplicationVersion = null)
 		{
 			var url = await StartService();
-			var client = new ConnectionApiClient(url);
+			var client = new ConnectionApiClient(url, clientApplication, clientApplicationVersion);
 			await client.CreateAsync();
 			return client;
 		}

--- a/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ClientApplicationIdentityTests.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ClientApplicationIdentityTests.cs
@@ -64,10 +64,35 @@ namespace ST_ConRestApiClient
 		[Test]
 		public void ALongName_IsCutRatherThanSentWhole()
 		{
-			string value = ClientApplicationIdentity.Format(new string('x', 100), "1.0");
+			string value = ClientApplicationIdentity.Format(new string('x', 100));
 
 			Assert.That(value, Has.Length.EqualTo(ClientApplicationIdentity.MaxLength));
 			Assert.That(value, Is.EqualTo(new string('x', ClientApplicationIdentity.MaxLength)));
+		}
+
+		/// <summary>
+		/// Attribution is by application AND version, so a version must never arrive half-written: a
+		/// value cut mid-field reads as a different version, which is worse than no version at all.
+		/// The name is what gives way.
+		/// </summary>
+		[Test]
+		public void WhenBothDoNotFit_TheNameGivesWayAndTheVersionStaysWhole()
+		{
+			Assert.Multiple(() =>
+			{
+				Assert.That(ClientApplicationIdentity.Format(new string('x', 63), "1.4.2"),
+					Is.EqualTo(new string('x', 58) + "/1.4.2"),
+					"no dangling separator and no lost version");
+				Assert.That(ClientApplicationIdentity.Format(new string('x', 60), "1.4.2"),
+					Is.EqualTo(new string('x', 58) + "/1.4.2"),
+					"1.4.2 must not arrive as 1.4");
+				Assert.That(ClientApplicationIdentity.Format("Norsok", new string('9', 100)),
+					Is.EqualTo("Norsok"),
+					"a version that cannot fit whole is dropped, not trimmed");
+			});
+
+			Assert.That(ClientApplicationIdentity.Format(new string('x', 100), "1.4.2"),
+				Has.Length.EqualTo(ClientApplicationIdentity.MaxLength));
 		}
 	}
 }

--- a/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ClientApplicationIdentityTests.cs
+++ b/src/api-sdks/connection-api/clients/csharp/src/tests/ST_ConRestApiClient/ClientApplicationIdentityTests.cs
@@ -1,0 +1,73 @@
+using IdeaStatiCa.ConnectionApi;
+
+namespace ST_ConRestApiClient
+{
+	/// <summary>
+	/// What an application is allowed to call itself towards the service. The value travels in a
+	/// request header on every call, so the rules are about what a header can safely carry.
+	/// </summary>
+	[TestFixture]
+	public class ClientApplicationIdentityTests
+	{
+		[Test]
+		public void AnApplicationAndItsVersion_AreJoinedByASlash()
+		{
+			Assert.Multiple(() =>
+			{
+				Assert.That(ClientApplicationIdentity.Format("NorsokChecker", "1.4.2"),
+					Is.EqualTo("NorsokChecker/1.4.2"));
+				Assert.That(ClientApplicationIdentity.Format("NorsokChecker"),
+					Is.EqualTo("NorsokChecker"), "the version is optional");
+				Assert.That(ClientApplicationIdentity.Format(" NorsokChecker ", " 1.4.2 "),
+					Is.EqualTo("NorsokChecker/1.4.2"), "trimmed, because a name is typed by a developer");
+			});
+		}
+
+		/// <summary>
+		/// Nothing to send is not an error - it is the previous behaviour, where calls are counted but
+		/// not attributed.
+		/// </summary>
+		[Test]
+		public void WithoutAName_ThereIsNoHeaderToSend()
+		{
+			Assert.Multiple(() =>
+			{
+				Assert.That(ClientApplicationIdentity.Format(null), Is.Null);
+				Assert.That(ClientApplicationIdentity.Format(""), Is.Null);
+				Assert.That(ClientApplicationIdentity.Format("   "), Is.Null);
+				Assert.That(ClientApplicationIdentity.Format(null, "1.4.2"), Is.Null,
+					"a version without a name identifies nothing");
+			});
+		}
+
+		/// <summary>
+		/// A header value with a control character in it is rejected outright by some HTTP stacks and
+		/// mangled by others, so a careless name must not be able to break every request the client
+		/// makes. The value stays recognisable rather than disappearing.
+		/// </summary>
+		[Test]
+		public void AnythingAHeaderCannotCarry_IsReplacedRatherThanSent()
+		{
+			Assert.Multiple(() =>
+			{
+				Assert.That(ClientApplicationIdentity.Format("Norsok\r\nChecker"),
+					Is.EqualTo("Norsok__Checker"), "a header injection attempt is not a name");
+				Assert.That(ClientApplicationIdentity.Format("Norsok\tChecker"),
+					Is.EqualTo("Norsok_Checker"));
+				Assert.That(ClientApplicationIdentity.Format("Kontrola spojů"),
+					Is.EqualTo("Kontrola spoj_"), "printable ASCII only");
+				Assert.That(ClientApplicationIdentity.Format("Norsok/Checker", "1.0"),
+					Is.EqualTo("Norsok_Checker/1.0"), "the slash is reserved for joining the version");
+			});
+		}
+
+		[Test]
+		public void ALongName_IsCutRatherThanSentWhole()
+		{
+			string value = ClientApplicationIdentity.Format(new string('x', 100), "1.0");
+
+			Assert.That(value, Has.Length.EqualTo(ClientApplicationIdentity.MaxLength));
+			Assert.That(value, Is.EqualTo(new string('x', ClientApplicationIdentity.MaxLength)));
+		}
+	}
+}

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/client_application_identity.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/client_application_identity.py
@@ -1,0 +1,64 @@
+from typing import Optional
+
+
+class ClientApplicationIdentity:
+    """The name an application gives itself towards the Connection REST API service.
+
+    Why it exists: the service reports every endpoint call it serves, and without this every call
+    looks the same. It cannot tell one python script from another, from a Grasshopper component,
+    from a partner's tool, because the only thing a client is identified by is the ClientId it was
+    handed, which is a fresh GUID per session.
+
+    One string in a request header answers it for every client. Sending nothing keeps the previous
+    behaviour: the calls are counted, just not attributed.
+
+    It identifies the APPLICATION, not the user: it is meant to be a constant of the release, and
+    nothing about the machine, the project or the person belongs in it.
+    """
+
+    HEADER_NAME = "X-Idea-Client-App"
+    """The request header the service reads the identification from. The C# client holds the same
+    string in ``ClientApplicationIdentity.HeaderName``: it is a wire contract between separately
+    shipped sides.
+
+    A caller that sets this header itself, without :meth:`format`, has to keep the value printable
+    ASCII: a byte above 0x7F in a header value makes the service's HTTP stack answer with a bare
+    400 before the service is reached, so a name with a diacritic fails every call rather than
+    arriving mangled.
+    """
+
+    MAX_LENGTH = 64
+    """The longest value that is sent. It is a name, not a payload, and it travels on every
+    request; anything longer is cut."""
+
+    @staticmethod
+    def format(application: Optional[str], version: Optional[str] = None) -> Optional[str]:
+        """The header value for an application name and an optional version, or ``None`` when
+        there is nothing to send.
+
+        The result is restricted to printable ASCII. A byte above 0x7F costs the whole request -
+        the service's HTTP stack answers a bare 400 before the service itself is reached - and a
+        control character below 0x20 has no business in a value that ends up in a log line.
+        Anything outside the range becomes ``_``, so a name never fails a call and stays
+        recognisable rather than disappearing.
+
+        :param application: For example ``"NorsokChecker"``. Optional.
+        :param version: For example ``"1.4.2"``. Optional.
+        """
+        name = ClientApplicationIdentity._sanitize(application)
+        if not name:
+            return None
+
+        suffix = ClientApplicationIdentity._sanitize(version)
+        value = name if not suffix else f"{name}/{suffix}"
+
+        return value if len(value) <= ClientApplicationIdentity.MAX_LENGTH \
+            else value[:ClientApplicationIdentity.MAX_LENGTH]
+
+    @staticmethod
+    def _sanitize(text: Optional[str]) -> str:
+        if text is None or not text.strip():
+            return ""
+
+        # 0x20-0x7E is printable ASCII; the separator is reserved for joining name and version
+        return "".join(c if " " <= c <= "~" and c != "/" else "_" for c in text.strip())

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/client_application_identity.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/client_application_identity.py
@@ -50,10 +50,17 @@ class ClientApplicationIdentity:
             return None
 
         suffix = ClientApplicationIdentity._sanitize(version)
-        value = name if not suffix else f"{name}/{suffix}"
+        if not suffix:
+            return name[:ClientApplicationIdentity.MAX_LENGTH]
 
-        return value if len(value) <= ClientApplicationIdentity.MAX_LENGTH \
-            else value[:ClientApplicationIdentity.MAX_LENGTH]
+        # The name gives way before the version does. A version cut in half reads as a different
+        # version - which is worse than no version at all, since attributing by version is the
+        # point - so when even a whole version does not fit, it is dropped rather than trimmed.
+        room = ClientApplicationIdentity.MAX_LENGTH - len(suffix) - 1
+        if room < 1:
+            return name[:ClientApplicationIdentity.MAX_LENGTH]
+
+        return f"{name[:room]}/{suffix}"
 
     @staticmethod
     def _sanitize(text: Optional[str]) -> str:

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_client.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_client.py
@@ -7,15 +7,29 @@ import ideastatica_connection_api.api_ext.project_ext_api as project_ext_api
 import ideastatica_connection_api.api_ext.export_ext_api as export_ext_api
 import ideastatica_connection_api.api_ext.report_ext_api as report_ext_api
 import ideastatica_connection_api.api_ext.connection_library_ext_api as connection_library_ext_api
+from ideastatica_connection_api.client_application_identity import ClientApplicationIdentity
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 class ConnectionApiClient:
-    def __init__(self, base_url: str):
+    def __init__(self, base_url: str, client_application: Optional[str] = None,
+                 client_application_version: Optional[str] = None):
+        """
+        :param base_url: URL of the REST API service.
+        :param client_application: Name of the application making the calls, for example
+            "NorsokChecker" - a constant of the release, not anything about the machine, the
+            project or the user. It is reported with every call the service serves, which is what
+            lets usage be attributed to an integration at all; see
+            :class:`ClientApplicationIdentity`. Optional.
+        :param client_application_version: Version of that application. Optional.
+        """
         self.base_url = base_url
         self.configuration = Configuration(host=self.base_url)
-        
+
+        self.client_application = ClientApplicationIdentity.format(client_application,
+                                                                   client_application_version)
+
         self.client: Optional[api_client.ApiClient] = None
         self.client_id: Optional[str] = None
 
@@ -39,6 +53,11 @@ class ConnectionApiClient:
     def __enter__(self):
         # Initialize the client with the provided config
         self.client = api_client.ApiClient(self.configuration)
+
+        # Set before the first call, so the service can attribute the connect itself. A service
+        # that does not know the header ignores it, so this is safe against any version.
+        if self.client_application is not None:
+            self.client.default_headers[ClientApplicationIdentity.HEADER_NAME] = self.client_application
 
         client_api = ClientApi(self.client)
         self.client_id = client_api.connect_client()

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_service_attacher.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_service_attacher.py
@@ -5,16 +5,21 @@ from ideastatica_connection_api.connection_api_client import ConnectionApiClient
 logger = logging.getLogger(__name__)
 
 class ConnectionApiServiceAttacher:
-    def __init__(self, base_url: str):
-        self.base_url = base_url
-
-    def create_api_client(self, client_application: Optional[str] = None,
-                          client_application_version: Optional[str] = None) -> ConnectionApiClient:
-        """Creates a client attached to the running service.
-
-        :param client_application: Name of the application making the calls, so its usage can be
-            told apart from every other caller's. Optional.
+    def __init__(self, base_url: str, client_application: Optional[str] = None,
+                 client_application_version: Optional[str] = None):
+        """
+        :param base_url: URL of the running REST API service.
+        :param client_application: Name of the application making the calls, for example
+            "NorsokChecker" - a constant of the release, so it belongs to the factory rather than to
+            a single call. Every client this factory creates is reported under it, which is what
+            lets usage be attributed to an integration at all. Optional.
         :param client_application_version: Version of that application. Optional.
         """
+        self.base_url = base_url
+        self.client_application = client_application
+        self.client_application_version = client_application_version
+
+    def create_api_client(self) -> ConnectionApiClient:
         logger.info(f"Creating client attached to {self.base_url}")
-        return ConnectionApiClient(self.base_url, client_application, client_application_version)
+        return ConnectionApiClient(self.base_url, self.client_application,
+                                   self.client_application_version)

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_service_attacher.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_service_attacher.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 from ideastatica_connection_api.connection_api_client import ConnectionApiClient
 
 logger = logging.getLogger(__name__)
@@ -7,6 +8,13 @@ class ConnectionApiServiceAttacher:
     def __init__(self, base_url: str):
         self.base_url = base_url
 
-    def create_api_client(self) -> ConnectionApiClient:
+    def create_api_client(self, client_application: Optional[str] = None,
+                          client_application_version: Optional[str] = None) -> ConnectionApiClient:
+        """Creates a client attached to the running service.
+
+        :param client_application: Name of the application making the calls, so its usage can be
+            told apart from every other caller's. Optional.
+        :param client_application_version: Version of that application. Optional.
+        """
         logger.info(f"Creating client attached to {self.base_url}")
-        return ConnectionApiClient(self.base_url) 
+        return ConnectionApiClient(self.base_url, client_application, client_application_version)

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_service_runner.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_service_runner.py
@@ -15,10 +15,21 @@ class ConnectionApiServiceRunner:
     HEARTBEAT = "heartbeat"
     API_EXECUTABLE_NAME = "IdeaStatiCa.ConnectionRestApi.exe"
 
-    def __init__(self, setup_dir: str):
+    def __init__(self, setup_dir: str, client_application: Optional[str] = None,
+                 client_application_version: Optional[str] = None):
+        """
+        :param setup_dir: Directory where the service executable is located.
+        :param client_application: Name of the application making the calls, for example
+            "NorsokChecker" - a constant of the release, so it belongs to the factory rather than to
+            a single call. Every client this factory creates is reported under it, which is what
+            lets usage be attributed to an integration at all. Optional.
+        :param client_application_version: Version of that application. Optional.
+        """
         self.setup_dir = setup_dir
         self.service_process: Optional[subprocess.Popen] = None
         self.port: Optional[int] = None
+        self.client_application = client_application
+        self.client_application_version = client_application_version
 
     async def __aenter__(self):
         """Start the API service when entering the asynchronous context."""
@@ -50,19 +61,14 @@ class ConnectionApiServiceRunner:
             self.service_process = None
         logger.info("API service stopped.")
 
-    def create_api_client(self, client_application: Optional[str] = None,
-                          client_application_version: Optional[str] = None) -> ConnectionApiClient:
-        """Creates and returns an IdeaStatiCaClient attached to the API service.
-
-        :param client_application: Name of the application making the calls, so its usage can be
-            told apart from every other caller's. Optional.
-        :param client_application_version: Version of that application. Optional.
-        """
+    def create_api_client(self) -> ConnectionApiClient:
+        """Creates and returns an IdeaStatiCaClient attached to the API service."""
         if self.port is None:
             raise RuntimeError("The service must be started before creating a client.")
 
         base_url = f"{self.LOCALHOST_URL}:{self.port}"
-        client = ConnectionApiClient(base_url, client_application, client_application_version)
+        client = ConnectionApiClient(base_url, self.client_application,
+                                     self.client_application_version)
         logger.info(f"Client created for service at {base_url}")
         return client
 

--- a/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_service_runner.py
+++ b/src/api-sdks/connection-api/clients/python/ideastatica_connection_api/connection_api_service_runner.py
@@ -50,13 +50,19 @@ class ConnectionApiServiceRunner:
             self.service_process = None
         logger.info("API service stopped.")
 
-    def create_api_client(self) -> ConnectionApiClient:
-        """Creates and returns an IdeaStatiCaClient attached to the API service."""
+    def create_api_client(self, client_application: Optional[str] = None,
+                          client_application_version: Optional[str] = None) -> ConnectionApiClient:
+        """Creates and returns an IdeaStatiCaClient attached to the API service.
+
+        :param client_application: Name of the application making the calls, so its usage can be
+            told apart from every other caller's. Optional.
+        :param client_application_version: Version of that application. Optional.
+        """
         if self.port is None:
             raise RuntimeError("The service must be started before creating a client.")
 
         base_url = f"{self.LOCALHOST_URL}:{self.port}"
-        client = ConnectionApiClient(base_url)
+        client = ConnectionApiClient(base_url, client_application, client_application_version)
         logger.info(f"Client created for service at {base_url}")
         return client
 

--- a/src/api-sdks/connection-api/clients/python/tests/test_client_application_identity.py
+++ b/src/api-sdks/connection-api/clients/python/tests/test_client_application_identity.py
@@ -1,0 +1,62 @@
+import sys
+import os
+
+# Get the parent directory
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+# Add the parent directory to sys.path, ahead of anything already installed - these assert what
+# the repository holds, and a pip-installed copy of the package would otherwise answer instead.
+sys.path.insert(0, parent_dir)
+
+from ideastatica_connection_api.client_application_identity import ClientApplicationIdentity
+
+# What an application is allowed to call itself towards the service. The value travels in a request
+# header on every call, so the rules are about what a header can safely carry. These need no running
+# service.
+
+
+def test_an_application_and_its_version_are_joined_by_a_slash():
+    assert ClientApplicationIdentity.format("NorsokChecker", "1.4.2") == "NorsokChecker/1.4.2"
+    # the version is optional
+    assert ClientApplicationIdentity.format("NorsokChecker") == "NorsokChecker"
+    # trimmed, because a name is typed by a developer
+    assert ClientApplicationIdentity.format(" NorsokChecker ", " 1.4.2 ") == "NorsokChecker/1.4.2"
+
+
+def test_without_a_name_there_is_no_header_to_send():
+    # Nothing to send is not an error - it is the previous behaviour, where calls are counted but
+    # not attributed.
+    assert ClientApplicationIdentity.format(None) is None
+    assert ClientApplicationIdentity.format("") is None
+    assert ClientApplicationIdentity.format("   ") is None
+    # a version without a name identifies nothing
+    assert ClientApplicationIdentity.format(None, "1.4.2") is None
+
+
+def test_anything_a_header_cannot_carry_is_replaced_rather_than_sent():
+    # A careless name must not be able to break every request the client makes: a byte above 0x7F
+    # is answered with a bare 400 by the service's HTTP stack, and a control character is mangled by
+    # whatever handles it. The value stays recognisable rather than disappearing.
+    assert ClientApplicationIdentity.format("Norsok\r\nChecker") == "Norsok__Checker"
+    assert ClientApplicationIdentity.format("Norsok\tChecker") == "Norsok_Checker"
+    # printable ASCII only
+    assert ClientApplicationIdentity.format("Kontrola spojů") == "Kontrola spoj_"
+    # the slash is reserved for joining the version
+    assert ClientApplicationIdentity.format("Norsok/Checker", "1.0") == "Norsok_Checker/1.0"
+
+
+def test_a_long_name_is_cut_rather_than_sent_whole():
+    value = ClientApplicationIdentity.format("x" * 100, "1.0")
+
+    assert len(value) == ClientApplicationIdentity.MAX_LENGTH
+    assert value == "x" * ClientApplicationIdentity.MAX_LENGTH
+
+
+def test_an_unnamed_client_sends_no_header():
+    # The header is what the service reads; a client that was given no name must not send the
+    # header at all, rather than send it empty.
+    from ideastatica_connection_api.connection_api_client import ConnectionApiClient
+
+    assert ConnectionApiClient("http://localhost:5000").client_application is None
+    assert ConnectionApiClient("http://localhost:5000", "NorsokChecker",
+                               "1.4.2").client_application == "NorsokChecker/1.4.2"

--- a/src/api-sdks/connection-api/clients/python/tests/test_client_application_identity.py
+++ b/src/api-sdks/connection-api/clients/python/tests/test_client_application_identity.py
@@ -46,10 +46,24 @@ def test_anything_a_header_cannot_carry_is_replaced_rather_than_sent():
 
 
 def test_a_long_name_is_cut_rather_than_sent_whole():
-    value = ClientApplicationIdentity.format("x" * 100, "1.0")
+    value = ClientApplicationIdentity.format("x" * 100)
 
     assert len(value) == ClientApplicationIdentity.MAX_LENGTH
     assert value == "x" * ClientApplicationIdentity.MAX_LENGTH
+
+
+def test_when_both_do_not_fit_the_name_gives_way_and_the_version_stays_whole():
+    # Attribution is by application AND version, so a version must never arrive half-written: a
+    # value cut mid-field reads as a different version, which is worse than no version at all.
+    # no dangling separator and no lost version
+    assert ClientApplicationIdentity.format("x" * 63, "1.4.2") == "x" * 58 + "/1.4.2"
+    # 1.4.2 must not arrive as 1.4
+    assert ClientApplicationIdentity.format("x" * 60, "1.4.2") == "x" * 58 + "/1.4.2"
+    # a version that cannot fit whole is dropped, not trimmed
+    assert ClientApplicationIdentity.format("Norsok", "9" * 100) == "Norsok"
+
+    assert len(ClientApplicationIdentity.format("x" * 100, "1.4.2")) == \
+        ClientApplicationIdentity.MAX_LENGTH
 
 
 def test_an_unnamed_client_sends_no_header():
@@ -60,3 +74,15 @@ def test_an_unnamed_client_sends_no_header():
     assert ConnectionApiClient("http://localhost:5000").client_application is None
     assert ConnectionApiClient("http://localhost:5000", "NorsokChecker",
                                "1.4.2").client_application == "NorsokChecker/1.4.2"
+
+
+def test_the_factories_carry_the_name_so_the_interface_call_stays_parameterless():
+    # The name is a constant of the release, so it belongs to the factory, not to a create call -
+    # otherwise code holding the factory by its interface could not identify itself at all.
+    from ideastatica_connection_api.connection_api_service_attacher import ConnectionApiServiceAttacher
+
+    attacher = ConnectionApiServiceAttacher("http://localhost:5000", "NorsokChecker", "1.4.2")
+
+    assert attacher.create_api_client().client_application == "NorsokChecker/1.4.2"
+    assert ConnectionApiServiceAttacher("http://localhost:5000").create_api_client() \
+        .client_application is None


### PR DESCRIPTION
The service reports every endpoint call it serves, and every call looks the same: the only thing a client is identified by is the ClientId it was handed, a fresh GUID per session. So a python script, a Grasshopper component, a partner's desktop tool and one of our own examples are one undifferentiated stream, and we cannot answer which integrations are actually used. An application that wanted to be counted had to report its own events through `IdeaStatiCa.Diagnostics`, which is not published outside the company - which is exactly why the NorsokChecker example reached out of the public repository into the monorepo to reference it.

One string answers it for every client, whatever it is written in:

```csharp
var runner = new ConnectionApiServiceRunner(setupDir, "NorsokChecker", "1.4.2");
var client = await runner.CreateApiClient();
```

```python
attacher = ConnectionApiServiceAttacher(base_url, "NorsokChecker", "1.4.2")
with attacher.create_api_client() as api_client:
    ...
```

The name sits on the **factory**, not on the create call: it is a constant of the build, and `IApiServiceFactory<T>.CreateApiClient()` is parameterless, so anything holding a factory by its interface - DI, the WPF example, the published snippets - can identify itself without a change at the call site.

It travels in a request header rather than a parameter of the connect call, deliberately: identifying an application then needs no change to any endpoint, no regenerated client, and no service newer than the one the customer has - an older service ignores a header it does not know. It is set before the first call, so the connect itself is attributed too.

It identifies the **application**, not the user: nothing about the machine, the project or the person belongs in it. Sending nothing keeps today's behaviour, where calls are counted but not attributed.

The value is restricted to printable ASCII and cut at 64 characters, because it travels on every request. A byte above 0x7F is answered with a bare 400 by the service's HTTP stack before the service is reached, so a name with a diacritic would otherwise fail every call. When name and version together do not fit, the name gives way and the version stays whole - a version cut mid-field reads as a different version.

**Both SDKs.** The python client gets the same opt-in through hand-written files only; `api_client.py`, `configuration.py`, `__init__.py`, `README.md` and `setup.py` are in `.openapi-generator/FILES` and are untouched, so a regeneration cannot eat this.

**Docs.** `connection_api_getting_started.md` and `connection_api_llm_reference.md` pass a name in their snippets and say what belongs in it. The csharp client README is generated, so it is left alone.

**The service half** - reading the header, stamping it on the event the service already reports and on the log scope - is in the ConnectionRestApi repository under the same work item.

> **Not covered by CI.** The offline tests in this PR (C# in `ST_ConRestApiClient`, python in `clients/python/tests`) are never run by any workflow: `dotnet test` runs on `IdeaStatiCa.Public.sln` only, `ST_ConRestApiClient` is not in it, and no workflow calls `pytest`. Adding `ST_ConRestApiClient` to that solution would turn CI red, because its other tests need a live service. Filed as **AB#36988**.

Work item #36924.

AI-assisted PR - human review required