### PR TITLE
Keep one traversal of a Tekla contour that describes the outline twice

### DIFF
--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCa.TeklaStructuresPlugin.projitems
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/IdeaStatiCa.TeklaStructuresPlugin.projitems
@@ -58,6 +58,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IdentifierComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\IdentifierHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\MemberHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\PlateContour.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\StringExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\TeklaGeometryExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\TeklaPropertiesKeys.cs" />

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Importers/FoldedPlateImporter.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Importers/FoldedPlateImporter.cs
@@ -7,6 +7,7 @@ using IdeaStatiCa.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApiLink.Utils;
 using IdeaStatiCa.Plugin;
 using IdeaStatiCa.TeklaStructuresPlugin.BimApi;
+using IdeaStatiCa.TeklaStructuresPlugin.Utils;
 using System.Collections;
 using System.Collections.Generic;
 using TSG = Tekla.Structures.Geometry3d;
@@ -113,9 +114,18 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Importers
 			};
 
 			List<TSG.Point> points = new List<TSG.Point>();
+			List<IPoint3D> contourPoints = new List<IPoint3D>();
 			foreach (TSM.ContourPoint point in node.Contour.ContourPoints)
 			{
 				points.Add(point);
+				contourPoints.Add(new Point3D(point.X, point.Y, point.Z));
+			}
+
+			PlateContour.FindFirstClosedContour(contourPoints, out int contourStart, out int contourCount);
+			if (contourCount < points.Count)
+			{
+				PlugInLogger.LogWarning($"FoldedPlateImporter GetPlateDataFromPolygon '{bentPlate.Identifier.GUID}' contour describes the outline more than once, {points.Count} points reduced to {contourCount}");
+				points = points.GetRange(contourStart, contourCount);
 			}
 
 			WM.Vector3D proLcsYT = points[1].ToMediaPoint() - points[0].ToMediaPoint();

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Importers/PlateImporter.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Importers/PlateImporter.cs
@@ -5,6 +5,7 @@ using IdeaStatiCa.BimApiLink.Identifiers;
 using IdeaStatiCa.BimApiLink.Utils;
 using IdeaStatiCa.Plugin;
 using IdeaStatiCa.TeklaStructuresPlugin.BimApi;
+using IdeaStatiCa.TeklaStructuresPlugin.Utils;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -177,11 +178,19 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Importers
 
 			var vertexEnumerator = firstLoop.GetVertexEnumerator();
 
-			List<TSG.Point> points = new List<TSG.Point>();
+			List<IPoint3D> loopVertices = new List<IPoint3D>();
 			while (vertexEnumerator.MoveNext())
 			{
-				points.Add(vertexEnumerator.Current);
+				var vertex = vertexEnumerator.Current;
+				loopVertices.Add(new Point3D(vertex.X, vertex.Y, vertex.Z));
 			}
+
+			IReadOnlyList<IPoint3D> points = PlateContour.FirstClosedContour(loopVertices);
+			if (points.Count < loopVertices.Count)
+			{
+				PlugInLogger.LogWarning($"PlateImporter CreatePlateFromSolid '{part.Identifier.GUID}' face loop walks the contour more than once, {loopVertices.Count} vertices reduced to {points.Count}");
+			}
+
 			TSG.Point origin = partCs.Origin;
 			if (part is TSM.Beam beam)
 			{

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/BulkSelectionHelper.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/BulkSelectionHelper.cs
@@ -253,13 +253,14 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Utilities
 			WM.Vector3D pltAxisZ = new WM.Vector3D(axisZ.X, axisZ.Y, axisZ.Z);
 			pltAxisZ.Normalize();
 
-			List<WM.Point3D> points = new List<WM.Point3D>();
-			List<CI.Geometry3D.IPoint3D> cIPoints = new List<CI.Geometry3D.IPoint3D>();
+			List<CI.Geometry3D.IPoint3D> contourPoints = new List<CI.Geometry3D.IPoint3D>();
 			foreach (ContourPoint point in node.Contour.ContourPoints)
 			{
-				points.Add(new WM.Point3D(point.X, point.Y, point.Z));
-				cIPoints.Add(new CI.Geometry3D.Point3D(point.X, point.Y, point.Z));
+				contourPoints.Add(new CI.Geometry3D.Point3D(point.X, point.Y, point.Z));
 			}
+
+			List<CI.Geometry3D.IPoint3D> cIPoints = PlateContour.FirstClosedContour(contourPoints).ToList();
+			List<WM.Point3D> points = cIPoints.Select(p => new WM.Point3D(p.X, p.Y, p.Z)).ToList();
 
 			WM.Vector3D translation = new WM.Vector3D(points[0].X, points[0].Y, points[0].Z);
 
@@ -344,7 +345,7 @@ namespace IdeaStatiCa.TeklaStructuresPlugin.Utilities
 				points.Add(new CI.Geometry3D.Point3D(vertexEnumerator.Current.X, vertexEnumerator.Current.Y, vertexEnumerator.Current.Z));
 			}
 
-			return points;
+			return PlateContour.FirstClosedContour(points).ToList();
 		}
 
 		private static OBB CreateOrientedBoundingBox(Tekla.Structures.Model.Model model, Beam beam)

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/PlateContour.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresPlugin/Utils/PlateContour.cs
@@ -1,0 +1,77 @@
+using CI.Geometry3D;
+using System;
+using System.Collections.Generic;
+
+namespace IdeaStatiCa.TeklaStructuresPlugin.Utils
+{
+	public static class PlateContour
+	{
+		/// <summary>
+		/// Tolerance for treating two loop vertices as one point, in millimetres - the unit Tekla
+		/// reports solid geometry in.
+		/// </summary>
+		private const double CoincidentVertexToleranceMm = 1E-04;
+
+		/// <summary>
+		/// Returns the first closed contour in a sequence of vertices.
+		/// <para>
+		/// A Tekla contour can describe the same outline more than once, revisiting vertices it has
+		/// already reported - both a contour plate's own contour points and the face loop built from
+		/// them. Such a sequence closes on itself and describes no single region, so only the first
+		/// closed cycle is kept. A sequence that visits every vertex once is returned unchanged.
+		/// </para>
+		/// </summary>
+		public static IReadOnlyList<IPoint3D> FirstClosedContour(IReadOnlyList<IPoint3D> vertices)
+		{
+			FindFirstClosedContour(vertices, out int start, out int count);
+			if (count == vertices.Count)
+			{
+				return vertices;
+			}
+
+			var contour = new List<IPoint3D>(count);
+			for (int k = start; k < start + count; k++)
+			{
+				contour.Add(vertices[k]);
+			}
+
+			return contour;
+		}
+
+		/// <summary>
+		/// Locates the first closed contour as a range into <paramref name="vertices"/>, for callers
+		/// that hold their vertices in some other type and have to slice that list themselves.
+		/// <para>
+		/// The repeat is matched against every earlier vertex, not against the first one: nothing
+		/// promises a particular start vertex, so the repeated pair can straddle any rotation of the
+		/// sequence.
+		/// </para>
+		/// </summary>
+		public static void FindFirstClosedContour(IReadOnlyList<IPoint3D> vertices, out int start, out int count)
+		{
+			for (int j = 1; j < vertices.Count; j++)
+			{
+				// A cycle needs at least three vertices, so a repeat closer than that is not one.
+				for (int i = 0; i <= j - 3; i++)
+				{
+					if (IsCoincident(vertices[i], vertices[j]))
+					{
+						start = i;
+						count = j - i;
+						return;
+					}
+				}
+			}
+
+			start = 0;
+			count = vertices.Count;
+		}
+
+		private static bool IsCoincident(IPoint3D first, IPoint3D second)
+		{
+			return Math.Abs(first.X - second.X) <= CoincidentVertexToleranceMm
+				&& Math.Abs(first.Y - second.Y) <= CoincidentVertexToleranceMm
+				&& Math.Abs(first.Z - second.Z) <= CoincidentVertexToleranceMm;
+		}
+	}
+}

--- a/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresTest/PlateContourTest.cs
+++ b/src/bim-links/tekla/IdeaStatiCa.TeklaStructuresTest/PlateContourTest.cs
@@ -1,0 +1,152 @@
+using CI.Geometry3D;
+using FluentAssertions;
+using IdeaStatiCa.TeklaStructuresPlugin.Utils;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace IdeaStatiCa.TeklaStructuresTest
+{
+	public class PlateContourTest
+	{
+		/// <summary>
+		/// The four corners of a 12 mm stiffener whose Tekla face loop walks the contour twice,
+		/// taken from a hub import dump, in millimetres. The corner opposite the origin is
+		/// reported as two distinct points 0.036 mm apart - <c>C1</c> on the first traversal,
+		/// <c>C2</c> on the second - while A, B and D repeat bit-exactly.
+		/// </summary>
+		private static readonly Dictionary<string, IPoint3D> Corners = new Dictionary<string, IPoint3D>
+		{
+			["A"] = new Point3D(-3.0224783622908931E-11, 3.5029618830954734E-11, 0.0),
+			["B"] = new Point3D(0.0080533706975985386, 169.99993896414645, 0.0),
+			["C1"] = new Point3D(220.50875854430468, 169.98001098487539, 0.0),
+			["C2"] = new Point3D(220.50033569273467, 170.01535034034285, 0.0),
+			["D"] = new Point3D(220.50076293885876, -1.6098955047716714E-09, 0.0),
+		};
+
+		private const string DoubledLoop = "A,B,C1,D,A,B,C2,D";
+
+		[TestCase(0, "A,B,C1,D")]
+		[TestCase(1, "B,C1,D,A")]
+		[TestCase(2, "D,A,B,C2")]
+		[TestCase(3, "D,A,B,C2")]
+		[TestCase(4, "A,B,C2,D")]
+		[TestCase(5, "B,C2,D,A")]
+		[TestCase(6, "D,A,B,C1")]
+		[TestCase(7, "D,A,B,C1")]
+		public void DoubledLoopKeepsOneTraversalWhicheverVertexItStartsFrom(int rotation, string expected)
+		{
+			IReadOnlyList<IPoint3D> loop = Rotate(Contour(DoubledLoop), rotation);
+
+			var result = PlateContour.FirstClosedContour(loop);
+
+			Describe(result).Should().Be(expected);
+		}
+
+		[Test]
+		public void DoubledTriangleKeepsOneTraversal()
+		{
+			var result = PlateContour.FirstClosedContour(Contour("A,B,C1,A,B,C1"));
+
+			Describe(result).Should().Be("A,B,C1");
+		}
+
+		/// <summary>
+		/// A repeat two vertices apart cannot bound a region, so collapsing onto it would leave a
+		/// contour of a single point.
+		/// </summary>
+		[Test]
+		public void RepeatTooCloseToCloseACycleIsKept()
+		{
+			var loop = Contour("A,A,B,C1,D");
+
+			var result = PlateContour.FirstClosedContour(loop);
+
+			result.Should().BeSameAs(loop);
+		}
+
+		[Test]
+		public void LoopVisitingEveryVertexOnceIsUnchanged()
+		{
+			var loop = Contour("A,B,C1,D");
+
+			var result = PlateContour.FirstClosedContour(loop);
+
+			result.Should().BeSameAs(loop);
+		}
+
+		/// <summary>
+		/// The repeats seen in the field are bit-exact, but nothing in the Tekla API promises that,
+		/// so these two pin what the coincidence tolerance actually accepts and rejects.
+		/// </summary>
+		[Test]
+		public void RepeatWithinToleranceClosesTheContour()
+		{
+			var loop = Contour("A,B,C1,D").Append(Nudged("A", 0.00005)).ToList();
+
+			var result = PlateContour.FirstClosedContour(loop);
+
+			Describe(result).Should().Be("A,B,C1,D");
+		}
+
+		[Test]
+		public void RepeatOutsideToleranceDoesNotCloseTheContour()
+		{
+			var loop = Contour("A,B,C1,D").Append(Nudged("A", 0.0002)).ToList();
+
+			var result = PlateContour.FirstClosedContour(loop);
+
+			result.Should().BeSameAs(loop);
+		}
+
+		/// <summary>
+		/// The range primitive callers use when their vertices are not <see cref="IPoint3D"/> and they
+		/// have to slice their own list.
+		/// </summary>
+		[TestCase(0, 0, 4)]
+		[TestCase(2, 1, 4)]
+		public void RangeLocatesTheSameContourTheListOverloadReturns(int rotation, int expectedStart, int expectedCount)
+		{
+			IReadOnlyList<IPoint3D> loop = Rotate(Contour(DoubledLoop), rotation);
+
+			PlateContour.FindFirstClosedContour(loop, out int start, out int count);
+
+			start.Should().Be(expectedStart);
+			count.Should().Be(expectedCount);
+			Describe(loop.Skip(start).Take(count).ToList())
+				.Should().Be(Describe(PlateContour.FirstClosedContour(loop)));
+		}
+
+		[Test]
+		public void RangeSpansEverythingWhenNothingRepeats()
+		{
+			IReadOnlyList<IPoint3D> loop = Contour("A,B,C1,D");
+
+			PlateContour.FindFirstClosedContour(loop, out int start, out int count);
+
+			start.Should().Be(0);
+			count.Should().Be(4);
+		}
+
+		private static IPoint3D Nudged(string name, double byMm)
+		{
+			IPoint3D origin = Corners[name];
+			return new Point3D(origin.X + byMm, origin.Y, origin.Z);
+		}
+
+		private static IReadOnlyList<IPoint3D> Contour(string vertexNames)
+		{
+			return vertexNames.Split(',').Select(name => Corners[name]).ToList();
+		}
+
+		private static IReadOnlyList<IPoint3D> Rotate(IReadOnlyList<IPoint3D> loop, int by)
+		{
+			return Enumerable.Range(0, loop.Count).Select(i => loop[(i + by) % loop.Count]).ToList();
+		}
+
+		private static string Describe(IReadOnlyList<IPoint3D> contour)
+		{
+			return string.Join(",", contour.Select(point => Corners.First(corner => corner.Value == point).Key));
+		}
+	}
+}


### PR DESCRIPTION
Importing a node from a Tekla 2026 model failed on two 12 mm stiffeners with "Geometry of plate is not valid - plate outline is self intersected". Their outline traced the same rectangle twice - A,B,C1,D,A,B,C2,D - where A, B and D repeated bit-exactly and one corner appeared as two points 0.036 mm apart. In the plate plane the second traversal crosses the first, so the region is rejected.

The doubling is in the part's own contour: Contour.ContourPoints lists eight points for a plate that renders as a four-corner plate, because the duplicates overlay the originals. The solid only reproduces what it is given - all seven SolidCreationTypeEnum values report eight loop vertices, RAW among them, every contour point carries CHAMFER_NONE, and the face is planar to ~5e-10 mm. Tekla accepts the part, so the link has to tolerate it.

PlateContour keeps the first closed cycle and drops the rest. The repeat is matched against every earlier vertex rather than against the first, because neither the contour nor the loop enumerator promises a particular start vertex, and a start-anchored rule would silently not fire on a sequence that begins at the doubled corner. Keeping the first traversal loses 0.036 mm on one corner.

Applied wherever a contour is read: the face loop in PlateImporter, the contour points in FoldedPlateImporter - before they are used to derive the local coordinate system - and both readers in BulkSelectionHelper. PlateImporter and FoldedPlateImporter log a warning naming the part when they shorten a contour, so a recurrence is visible in the field.

The rule truncates at any vertex repeat that encloses at least three vertices, not only at a re-traced traversal, so a legitimately self-touching contour would lose the geometry outside the first closable cycle. No such contour appeared in 182 outlines across two nodes of the reporting model. Requiring the tail to re-trace the kept cycle would not fire on this data, since the two traversals differ at one corner.

Co-authored-by: Claude

* Did you find critical bug in our code?
* Do you have any new feature you want implemented?
* Did you fix anything?

# Propose PULL Request then and we will examine it
